### PR TITLE
#6 reverts changes made to login template and login styles

### DIFF
--- a/applications/accounts/themes/custom/login/login.ftl
+++ b/applications/accounts/themes/custom/login/login.ftl
@@ -88,6 +88,15 @@
             </div>
         </#if>
     </div>
+    <#elseif section = "info" >
+        <#if realm.password && realm.registrationAllowed && !registrationDisabled??>
+            <div id="kc-registration-container">
+                <div id="kc-registration">
+                    <span>${msg("noAccount")} <a tabindex="6"
+                                                 href="${url.registrationUrl}">${msg("doRegister")}</a></span>
+                </div>
+            </div>
+        </#if>
     </#if>
 
 </@layout.registrationLayout>

--- a/applications/accounts/themes/custom/login/resources/css/login.css
+++ b/applications/accounts/themes/custom/login/resources/css/login.css
@@ -285,6 +285,7 @@ div.kc-logo-text span {
 #kc-info-wrapper {
     font-size: 13px;
     padding: 15px 35px;
+    background-color: #F0F0F0;
 }
 
 #kc-form-options span {


### PR DESCRIPTION
Closes #6

Implemented solution: ... 
reverts the changes made to login template and styling .ie login.ftl and login.css. This new sign-in option can be turned off from  keyclaok's admin console without having to make changes to the template 

How to test this PR: ...

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] From the issue and the current PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [ ] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
