### PR TITLE
Feature/43 Highlight selected sidebar tabs and replace strings with constants

### DIFF
--- a/applications/salk-portal/src/components/ExplorerSidebar.jsx
+++ b/applications/salk-portal/src/components/ExplorerSidebar.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useLocation } from 'react-router-dom';
 import {makeStyles} from '@material-ui/core/styles';
 import {
   Box,
@@ -13,8 +14,6 @@ import {
   Link
 } from '@material-ui/core';
 import Collapse from '@material-ui/core/Collapse';
-import ExpandLess from '@material-ui/icons/ExpandLess';
-import ExpandMore from '@material-ui/icons/ExpandMore';
 import { headerBg, headerBorderColor, switchActiveColor, secondaryColor, headerButtonBorderColor, sidebarBadgeBg, sidebarTextColor } from "../theme";
 import SEARCH from "../assets/images/icons/search.svg";
 import EXP from "../assets/images/icons/experiments.svg";
@@ -23,7 +22,7 @@ import TEAMS from "../assets/images/icons/teams.svg";
 import COMMUNITY from "../assets/images/icons/community.svg";
 import HELP from "../assets/images/icons/help.svg";
 import UP_ICON from "../assets/images/icons/up.svg";
-
+import { EXPERIMENTS_HASH, SALK_TEAM, ACME_TEAM, COMMUNITY_HASH, SHARED_HASH } from "../constants";
 
 const useStyles = makeStyles({
   sidebar: {
@@ -171,6 +170,8 @@ const Sidebar = (props) => {
     setOpen(!open);
   };
 
+  const hash = useLocation()?.hash;
+
   return (
     <Box className={classes.sidebar}>
       <Box className="sidebar-header">
@@ -188,7 +189,7 @@ const Sidebar = (props) => {
         component="nav"
         disablePadding
       >
-        <ListItemLink href="#experiments" onClick={() => props.executeScroll('experiments')}>
+        <ListItemLink href="#experiments" onClick={() => props.executeScroll(EXPERIMENTS_HASH)} selected={hash === `#${EXPERIMENTS_HASH}` || hash === ''}>
           <ListItemIcon>
             <img src={EXP} alt="experiments" />
           </ListItemIcon>
@@ -196,7 +197,7 @@ const Sidebar = (props) => {
           <Badge badgeContent={4} />
         </ListItemLink>
 
-        <ListItemLink href="#shared" onClick={() => props.executeScroll('shared')} selected={true}>
+        <ListItemLink href="#shared" onClick={() => props.executeScroll(SHARED_HASH)} selected={hash === `#${SHARED_HASH}`}>
           <ListItemIcon>
             <img src={SHARED} alt="Shared" />
           </ListItemIcon>
@@ -213,12 +214,12 @@ const Sidebar = (props) => {
         </ListItem>
         <Collapse in={open} timeout="auto" unmountOnExit>
           <List component="div" disablePadding>
-            <ListItemLink href="#salkteam" onClick={() => props.executeScroll('salkteam')}>
+            <ListItemLink href="#salkteam" onClick={() => props.executeScroll(SALK_TEAM)} selected={hash === `#${SALK_TEAM}`}>
               <ListItemText primary="Salk Institute Team" />
               <Badge badgeContent={4} />
             </ListItemLink>
 
-            <ListItemLink href="#acmeteam" onClick={() => props.executeScroll('acmeteam')}>
+            <ListItemLink href="#acmeteam" onClick={() => props.executeScroll(ACME_TEAM)} selected={hash === `#${ACME_TEAM}`}>
               <ListItemText primary="Acme Team" />
               <Badge badgeContent={4} />
             </ListItemLink>
@@ -230,7 +231,7 @@ const Sidebar = (props) => {
         component="nav"
         disablePadding
       >
-        <ListItemLink href="#community" onClick={() => props.executeScroll('community')}>
+        <ListItemLink href="#community" onClick={() => props.executeScroll(COMMUNITY_HASH)} selected={hash ===  `#${COMMUNITY_HASH}`}>
           <ListItemIcon>
             <img src={COMMUNITY} alt="Community" />
           </ListItemIcon>

--- a/applications/salk-portal/src/constants.js
+++ b/applications/salk-portal/src/constants.js
@@ -1,0 +1,5 @@
+export const EXPERIMENTS_HASH = 'experiments';
+export const SHARED_HASH = 'shared';
+export const ACME_TEAM = 'acmeteam';
+export const SALK_TEAM = 'salkteam';
+export const COMMUNITY_HASH = 'community';

--- a/applications/salk-portal/src/pages/HomePage.tsx
+++ b/applications/salk-portal/src/pages/HomePage.tsx
@@ -5,6 +5,7 @@ import Sidebar from "../components/ExplorerSidebar";
 import { bodyBgColor } from "../theme";
 import ExperimentList from "../components/home/ExperimentList";
 import Community from "../components/home/Community";
+import { EXPERIMENTS_HASH, SALK_TEAM, ACME_TEAM, COMMUNITY_HASH, SHARED_HASH } from "../constants";
 
 const useStyles = makeStyles(() => ({
   layoutContainer: {
@@ -26,15 +27,15 @@ export default (props: any) => {
   const communityRef = useRef(null);
   const [selectedRef, setSelectedRef] =  useState(myRef);
   const executeScroll = (selRef: string) => {
-    if (selRef === 'experiments') {
+    if (selRef === EXPERIMENTS_HASH) {
       setSelectedRef(myRef);
-    } else if (selRef === 'shared') {
+    } else if (selRef === SHARED_HASH) {
       setSelectedRef(shared);
-    } else if (selRef === 'salkteam') {
+    } else if (selRef === SALK_TEAM) {
       setSelectedRef(salkteam);
-    } else if (selRef === 'acmeteam') {
+    } else if (selRef === ACME_TEAM) {
       setSelectedRef(acmeteam);
-    } else if (selRef === 'community') {
+    } else if (selRef === COMMUNITY_HASH) {
       setSelectedRef(communityRef);
     }
     selectedRef.current.scrollIntoView();
@@ -44,20 +45,20 @@ export default (props: any) => {
     <Box display="flex">
       <Sidebar executeScroll={(r: string) => executeScroll(r)} />
       <Box className={classes.layoutContainer}>
-        <div ref={myRef} id="experiments">
+        <div ref={myRef} id={EXPERIMENTS_HASH}>
           <ExperimentList heading={"My experiments"} description={"7 experiments"} />
         </div>
-        <div ref={shared} id="shared">
+        <div ref={shared} id={SHARED_HASH}>
           <ExperimentList heading={"Shared with me"} description={"28 experiments"} />
         </div>
-        <div ref={salkteam} id="salkteam">
+        <div ref={salkteam} id={SALK_TEAM}>
           <ExperimentList heading={"Salk Institute Team"} description={"19 experiments"} />
         </div>
-        <div ref={acmeteam} id="acmeteam">
+        <div ref={acmeteam} id={ACME_TEAM}>
           <ExperimentList heading={"Acme Team"} description={"19 experiments"} />
         </div>
         <Box p={5}>
-          <div ref={communityRef} id="community">
+          <div ref={communityRef} id={COMMUNITY_HASH}>
             <Community />
           </div>
         </Box>


### PR DESCRIPTION
Closes #43 

Implemented solution: ... 
Also  replaced hash values/id with constants

How to test this PR: ...

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [x] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [ ] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [x] Screenshots of the changes
- [ ] Explanatory video/animated gif
<img width="920" alt="Screen Shot 2022-03-15 at 5 44 36 PM" src="https://user-images.githubusercontent.com/71261494/158428713-07754499-0c7a-47b5-99f4-e0ca9a52e96f.png">

