### PR TITLE
#20 smoothes sidebar scroll and make canvas container background grey

### DIFF
--- a/applications/salk-portal/src/components/ExperimentSidebar.jsx
+++ b/applications/salk-portal/src/components/ExperimentSidebar.jsx
@@ -18,6 +18,7 @@ const useStyles = makeStyles({
     borderRight: `0.0625rem solid ${headerBorderColor}`,
     background: headerBg,
     overflow: 'auto',
+    transition: "all linear .1s",
 
     '& .sidebar-title': {
       flexGrow: 1,

--- a/applications/salk-portal/src/components/ExperimentViewer.jsx
+++ b/applications/salk-portal/src/components/ExperimentViewer.jsx
@@ -121,7 +121,8 @@ const styles = () => ({
     canvasContainer: {
         width: '100%',
         height: '100%',
-        overflow: 'hidden'
+        overflow: 'hidden',
+        backgroundColor:canvasBg
     },
 });
 


### PR DESCRIPTION
Closes #

Implemented solution: ... 
open and close the sidebar. The sidebar now scrolls with a linear transition and the black background of the canvas container
viewer has been changed from black to grey to make the flickering of the canvas less obvious when you scroll. 

How to test this PR: ...

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] From the issue and the current PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [x] Explanatory video/animated gif

https://user-images.githubusercontent.com/37967706/158544371-6558d40a-b724-4c53-8555-e783914bb35e.mp4



