### PR TITLE
fix: #40 links experiments card and page together

### DIFF
--- a/applications/salk-portal/src/App.tsx
+++ b/applications/salk-portal/src/App.tsx
@@ -53,7 +53,7 @@ export const App = (props: any) => {
                 <ProtectedRoute exact={true} path="/">
                   <HomePage />
                 </ProtectedRoute>
-                <ProtectedRoute exact={true} path="/experiments">
+                <ProtectedRoute exact={true} path="/experiments/:id">
                   <ExperimentsPage />
                 </ProtectedRoute>
               </Switch>

--- a/applications/salk-portal/src/components/home/ExperimentCard.jsx
+++ b/applications/salk-portal/src/components/home/ExperimentCard.jsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import {useHistory} from "react-router-dom"
 import { makeStyles } from "@material-ui/core/styles";
 import Card from '@material-ui/core/Card';
 import CardActionArea from '@material-ui/core/CardActionArea';
@@ -114,9 +115,14 @@ const useStyles = makeStyles(() => ({
 
 const ExperimentCard = (props) => {
   const classes = useStyles();
-  const { tags, heading, description, user, i, community } = props;
+  const { tags, heading, description, user, i, community, id } = props;
+  const history = useHistory()
+  const handleClick = () => {
+    history.push(`/experiments/${id}`)
+  }
+
   return (
-    <Grid item xs={12} md={3} key={i}>
+    <Grid item xs={12} md={3} key={i} onClick={handleClick}>
       <Card className={classes.card} elevation={0}>
         <CardActionArea>
           {community && <img src={POPULAR} alt="POPULAR" />}

--- a/applications/salk-portal/src/components/home/ExperimentList.jsx
+++ b/applications/salk-portal/src/components/home/ExperimentList.jsx
@@ -263,7 +263,7 @@ const ExperimentList = (props) => {
       <Box p={5}>
         <Grid container item spacing={3}>
           {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((item, i) => (
-            <ExperimentCard i={`${heading}experiment_${i}`} tags={tags} heading={"Exploration of the spinal cord"} description={"Shared on Sept 2nd, 2021"} user={"name"} />
+            <ExperimentCard id={i} i={`${heading}experiment_${i}`} tags={tags} heading={"Exploration of the spinal cord"} description={"Shared on Sept 2nd, 2021"} user={"name"} />
             ))
           }
         </Grid>


### PR DESCRIPTION
Closes #40 

Implemented solution: ... 
add URL params to router, id props on experiment card and. Since there's no backend atm, the index of the items are used as the id for the experiments

How to test this PR: ...
Click on the experiment card 

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x ] From the issue and the current PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [ ] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
