### PR TITLE
Feature/76

### DIFF
--- a/applications/salk-portal/src/pages/ExperimentsPage.tsx
+++ b/applications/salk-portal/src/pages/ExperimentsPage.tsx
@@ -98,6 +98,7 @@ const ExperimentsPage = () => {
     const [selectedAtlas, setSelectedAtlas] = useState(getDefaultAtlas());
     const [subdivisions, setSubdivisions] = useState(getSubdivisions(selectedAtlas));
     const [populations, setPopulations] = useState({});
+    const [widgetsReady, setWidgetsReady] = useState(false)
 
     const dispatch = useDispatch();
     const [LayoutComponent, setLayoutManager] = useState(undefined);
@@ -159,6 +160,7 @@ const ExperimentsPage = () => {
             setPopulations(getPopulations(experiment, selectedAtlas))
             dispatch(addWidget(CanvasWidget(selectedAtlas, new Set(), {})));
             dispatch(addWidget(ElectrophysiologyWidget));
+            setWidgetsReady(true)
         }
     }, [experiment])
 
@@ -173,7 +175,10 @@ const ExperimentsPage = () => {
                 obj[key] = populations[key];
                 return obj;
             }, {});
-        dispatch(updateWidget(CanvasWidget(selectedAtlas, subdivisionsSet, activePopulations)))
+
+        if (widgetsReady) {
+            dispatch(updateWidget(CanvasWidget(selectedAtlas, subdivisionsSet, activePopulations)))
+        }
     }, [subdivisions, populations, selectedAtlas])
 
     useEffect(() => {


### PR DESCRIPTION
Closes #76

Implemented solution: 
The problem was caused by trying to update a widget that didn't exist yet.
Implemented solution adds a state variable to know when the widgets were added to the page and only updates when the variable is set

How to test this PR: 
Run the application and you should no longer see the error prompted in the console when you open the experiments page

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
