### PR TITLE
#78 Disables tab dragging

### DIFF
--- a/applications/salk-portal/src/components/layout/defaultLayout.js
+++ b/applications/salk-portal/src/components/layout/defaultLayout.js
@@ -5,6 +5,7 @@ export default {
         tabSetTabStripHeight: 26,
         enableEdgeDock: false,
         borderBarSize: 0,
+        tabEnableDrag: false
     },
     layout: {
         type: "tabset",


### PR DESCRIPTION
Closes #78 

Implemented solution: 
Real fix needs to happen at the geppetto level. Current solution disables tab dragging (suggested by @ddelpiano )

How to test this PR: 
Open the experiment page, try to drag one tab. If you failed to do that, this PR succeeded 

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
