### PR TITLE
#80 Clean up of the explorer viewer

### DIFF
--- a/applications/salk-portal/src/components/ExplorerSidebar.jsx
+++ b/applications/salk-portal/src/components/ExplorerSidebar.jsx
@@ -207,7 +207,6 @@ const Sidebar = (props) => {
             <img src={SHARED} alt="Shared" />
           </ListItemIcon>
           <ListItemText primary="Shared with me" />
-          {/**<Badge badgeContent={4} />**/}
         </ListItemLink>
 
         <ListItem button onClick={handleClick}>
@@ -221,12 +220,10 @@ const Sidebar = (props) => {
           <List component="div" disablePadding>
             <ListItemLink href="#salkteam" onClick={() => props.executeScroll(SALK_TEAM)} selected={hash === `#${SALK_TEAM}`}>
               <ListItemText primary="Salk Institute Team" />
-              {/**<Badge badgeContent={4} />**/}
             </ListItemLink>
 
             <ListItemLink href="#acmeteam" onClick={() => props.executeScroll(ACME_TEAM)} selected={hash === `#${ACME_TEAM}`}>
               <ListItemText primary="Acme Team" />
-              {/**<Badge badgeContent={4} />**/}
             </ListItemLink>
           </List>
         </Collapse>
@@ -241,7 +238,6 @@ const Sidebar = (props) => {
             <img src={COMMUNITY} alt="Community" />
           </ListItemIcon>
           <ListItemText primary="Community" />
-          {/**<Badge badgeContent={4} />**/}
         </ListItemLink>
         <ListItemLink href="#simple-list">
           <ListItemIcon>

--- a/applications/salk-portal/src/components/ExplorerSidebar.jsx
+++ b/applications/salk-portal/src/components/ExplorerSidebar.jsx
@@ -199,7 +199,7 @@ const Sidebar = (props) => {
             <img src={EXP} alt="experiments" />
           </ListItemIcon>
           <ListItemText primary="My experiments" />
-          <Badge badgeContent={4} />
+          <Badge badgeContent={1} />
         </ListItemLink>
 
         <ListItemLink href="#shared" onClick={() => props.executeScroll(SHARED_HASH)} selected={hash === `#${SHARED_HASH}`}>
@@ -207,7 +207,7 @@ const Sidebar = (props) => {
             <img src={SHARED} alt="Shared" />
           </ListItemIcon>
           <ListItemText primary="Shared with me" />
-          <Badge badgeContent={4} />
+          {/**<Badge badgeContent={4} />**/}
         </ListItemLink>
 
         <ListItem button onClick={handleClick}>
@@ -221,12 +221,12 @@ const Sidebar = (props) => {
           <List component="div" disablePadding>
             <ListItemLink href="#salkteam" onClick={() => props.executeScroll(SALK_TEAM)} selected={hash === `#${SALK_TEAM}`}>
               <ListItemText primary="Salk Institute Team" />
-              <Badge badgeContent={4} />
+              {/**<Badge badgeContent={4} />**/}
             </ListItemLink>
 
             <ListItemLink href="#acmeteam" onClick={() => props.executeScroll(ACME_TEAM)} selected={hash === `#${ACME_TEAM}`}>
               <ListItemText primary="Acme Team" />
-              <Badge badgeContent={4} />
+              {/**<Badge badgeContent={4} />**/}
             </ListItemLink>
           </List>
         </Collapse>
@@ -241,7 +241,7 @@ const Sidebar = (props) => {
             <img src={COMMUNITY} alt="Community" />
           </ListItemIcon>
           <ListItemText primary="Community" />
-          <Badge badgeContent={4} />
+          {/**<Badge badgeContent={4} />**/}
         </ListItemLink>
         <ListItemLink href="#simple-list">
           <ListItemIcon>

--- a/applications/salk-portal/src/components/home/ExperimentList.jsx
+++ b/applications/salk-portal/src/components/home/ExperimentList.jsx
@@ -333,7 +333,7 @@ const ExperimentList = (props) => {
       </Box>
       <Box p={5}>
         <Grid container item spacing={3}>
-          {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map( i => (
+          {[1].map( i => (
             <ExperimentCard experiment={dummyExperiment} type={type} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle}/>
             ))
           }

--- a/applications/salk-portal/src/pages/HomePage.tsx
+++ b/applications/salk-portal/src/pages/HomePage.tsx
@@ -60,21 +60,6 @@ export default (props: any) => {
         <div ref={myRef} id={EXPERIMENTS_HASH}>
           <ExperimentList heading={"My experiments"} description={"1 experiments"} type={EXPERIMENTS_HASH} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false} />
         </div>
-        {/*<div ref={shared} id={SHARED_HASH}>*/}
-        {/*  <ExperimentList heading={"Shared with me"} description={"28 experiments"} type={SHARED_HASH} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false} />*/}
-        {/*</div>*/}
-        {/*<div ref={salkteam} id={SALK_TEAM}>*/}
-        {/*  <ExperimentList heading={"Salk Institute Team"} description={"19 experiments"} type={SALK_TEAM} handleDialogToggle={handleDialogToggle}handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={true} />*/}
-        {/*</div>*/}
-        {/*<div ref={acmeteam} id={ACME_TEAM}>*/}
-        {/*  <ExperimentList heading={"Acme Team"} description={"19 experiments"} type={ACME_TEAM} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false}/>*/}
-        {/*</div>*/}
-        {/*<Box p={5}>*/}
-        {/*  <div ref={communityRef} id={COMMUNITY_HASH}>*/}
-        {/*    <Community handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} />*/}
-        {/*  </div>*/}
-        {/*</Box>*/}
-
       </Box>
       <CloneExperimentDialog open={dialogOpen} handleClose={handleDialogToggle} user={props?.user} />
       <ExplorationSpinalCordDialog open={explorationDialogOpen} handleClose={handleExplorationDialogToggle} />

--- a/applications/salk-portal/src/pages/HomePage.tsx
+++ b/applications/salk-portal/src/pages/HomePage.tsx
@@ -58,22 +58,22 @@ export default (props: any) => {
       <Sidebar executeScroll={(r: string) => executeScroll(r)} />
       <Box className={classes.layoutContainer}>
         <div ref={myRef} id={EXPERIMENTS_HASH}>
-          <ExperimentList heading={"My experiments"} description={"7 experiments"} type={EXPERIMENTS_HASH} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false} />
+          <ExperimentList heading={"My experiments"} description={"1 experiments"} type={EXPERIMENTS_HASH} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false} />
         </div>
-        <div ref={shared} id={SHARED_HASH}>
-          <ExperimentList heading={"Shared with me"} description={"28 experiments"} type={SHARED_HASH} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false} />
-        </div>
-        <div ref={salkteam} id={SALK_TEAM}>
-          <ExperimentList heading={"Salk Institute Team"} description={"19 experiments"} type={SALK_TEAM} handleDialogToggle={handleDialogToggle}handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={true} />
-        </div>
-        <div ref={acmeteam} id={ACME_TEAM}>
-          <ExperimentList heading={"Acme Team"} description={"19 experiments"} type={ACME_TEAM} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false}/>
-        </div>
-        <Box p={5}>
-          <div ref={communityRef} id={COMMUNITY_HASH}>
-            <Community handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} />
-          </div>
-        </Box>
+        {/*<div ref={shared} id={SHARED_HASH}>*/}
+        {/*  <ExperimentList heading={"Shared with me"} description={"28 experiments"} type={SHARED_HASH} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false} />*/}
+        {/*</div>*/}
+        {/*<div ref={salkteam} id={SALK_TEAM}>*/}
+        {/*  <ExperimentList heading={"Salk Institute Team"} description={"19 experiments"} type={SALK_TEAM} handleDialogToggle={handleDialogToggle}handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={true} />*/}
+        {/*</div>*/}
+        {/*<div ref={acmeteam} id={ACME_TEAM}>*/}
+        {/*  <ExperimentList heading={"Acme Team"} description={"19 experiments"} type={ACME_TEAM} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false}/>*/}
+        {/*</div>*/}
+        {/*<Box p={5}>*/}
+        {/*  <div ref={communityRef} id={COMMUNITY_HASH}>*/}
+        {/*    <Community handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} />*/}
+        {/*  </div>*/}
+        {/*</Box>*/}
 
       </Box>
       <CloneExperimentDialog open={dialogOpen} handleClose={handleDialogToggle} user={props?.user} />


### PR DESCRIPTION
Closes #80 

Implemented solution: 
Comments out 'distracting' sections so that it's easier to showcase the POC to the customers

How to test this PR: 
Open explorer page and be prompted with only 1 experiment under my experiments 

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
![image](https://user-images.githubusercontent.com/19196034/161312069-551f85de-2554-4073-ab09-2a81b6b7d221.png)
