### PR TITLE
Feature/75 Share experiment - Multiple and single UI views

### DIFF
--- a/applications/salk-portal/src/assets/images/icons/checkbox-filled.svg
+++ b/applications/salk-portal/src/assets/images/icons/checkbox-filled.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13 2.5H3C2.44772 2.5 2 2.94772 2 3.5V13.5C2 14.0523 2.44772 14.5 3 14.5H13C13.5523 14.5 14 14.0523 14 13.5V3.5C14 2.94772 13.5523 2.5 13 2.5ZM7 11.25L4.5 8.75L5.295 8L7 9.675L10.705 6L11.5 6.79L7 11.25Z" fill="#7B61FF"/>
+</svg>

--- a/applications/salk-portal/src/assets/images/icons/checkbox.svg
+++ b/applications/salk-portal/src/assets/images/icons/checkbox.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="17" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M13 2.5H3C2.44772 2.5 2 2.94772 2 3.5V13.5C2 14.0523 2.44772 14.5 3 14.5H13C13.5523 14.5 14 14.0523 14 13.5V3.5C14 2.94772 13.5523 2.5 13 2.5ZM3 13.5V3.5H13V13.5H3Z" fill="white" fill-opacity="0.8"/>
+</svg>

--- a/applications/salk-portal/src/assets/images/icons/down.svg
+++ b/applications/salk-portal/src/assets/images/icons/down.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8 10.9998L3 5.9998L3.7 5.2998L8 9.5998L12.3 5.2998L13 5.9998L8 10.9998Z" fill="white" fill-opacity="0.6"/>
+</svg>

--- a/applications/salk-portal/src/components/common/ExperimentDialogs/ShareExperimentTabs.jsx
+++ b/applications/salk-portal/src/components/common/ExperimentDialogs/ShareExperimentTabs.jsx
@@ -1,0 +1,344 @@
+import * as React from "react";
+import {
+  Box,
+  makeStyles,
+  Typography,
+  TextField,
+  Button,
+  FormControl,
+  Select,
+  MenuItem,
+  List,
+  ListItem,
+  ListItemAvatar,
+  Avatar,
+  ListItemText,
+} from "@material-ui/core";
+import PropTypes from 'prop-types';
+import { canvasIconColor, cardTextColor, headerBorderColor, headerButtonBorderColor, sidebarBadgeBg, switchActiveColor, textDisabled } from "../../../theme";
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import USER from "../../../assets/images/icons/user.svg";
+import DOWN from "../../../assets/images/icons/down.svg";
+
+const userRoles = ['Viewer', 'Editor'];
+
+const styles = {
+  fontWeight: 500,
+  fontSize: '0.75rem',
+  lineHeight: '1rem',
+  letterSpacing: '0.01em',
+}
+
+const useStyles = makeStyles(() => ({
+  tabs: {
+    padding: '0.125rem 0.25rem 0.125rem 1rem',
+    boxShadow: `inset 0 -0.0625rem 0 ${headerBorderColor}`,
+    height: '2.75rem',
+    alignItems: 'center',
+  },
+
+  tabContent: {
+    minHeight: '19.0625rem',
+    '& .MuiTypography-root': {
+      marginBottom: '0.5rem',
+      color: cardTextColor,
+      ...styles,
+
+      '&.MuiTypography-body2': {
+        fontWeight: 600,
+        letterSpacing: '0.005em',
+        color: canvasIconColor,
+      },
+    },
+
+    '& .MuiButton-text': {
+      padding: 0,
+      color: switchActiveColor,
+      ...styles,
+
+      '&:hover': {
+        backgroundColor: 'transparent'
+      },
+    },
+  },
+
+  formGroup: {},
+
+  copyLink: {
+    marginBottom: '0.5rem',
+    '& .MuiButton-root': {
+      width: '5.75rem',
+      marginLeft: '0.8rem',
+      flexShrink: 0,
+    },
+
+    '& .MuiTypography-root': {
+      '&.MuiTypography-caption': {
+        ...styles,
+        background: sidebarBadgeBg,
+        borderRadius: '0.375rem',
+        padding: '0.5rem 0.75rem',
+        flexGrow: 1,
+        marginBottom: 0,
+        textOverflow: 'ellipsis',
+        whiteSpace: 'nowrap',
+        overflow: 'hidden',
+      }
+    },
+  },
+
+  collaborators: {
+    borderTop: `0.0625rem solid ${headerBorderColor}`,
+    paddingTop: '1.5rem',
+    marginTop: '1.5rem',
+
+    '& .MuiListItem-container': {
+      display: 'flex',
+      alignItems: 'center',
+    },
+
+    '& .MuiListItemSecondaryAction-root': {
+      position: 'static',
+      transform: 'none',
+      flexShrink: 0,
+      paddingLeft: '0.5rem',
+    },
+
+    '& .MuiButton-text': {
+      padding: 0,
+      fontWeight: 500,
+      fontSize: '0.75rem',
+      lineHeight: '1rem',
+      textTransform: 'none',
+      letterSpacing: '0.01em',
+      color: switchActiveColor,
+
+      '&:hover': {
+        backgroundColor: 'transparent',
+      },
+    },
+
+    '& .MuiList-padding': {
+      padding: 0,
+      marginBottom: '1.25rem',
+      '& li + li': {
+        marginTop: '0.5rem',
+      }
+    },
+
+    '& .MuiListItem-gutters': {
+      padding: 0,
+      '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
+        border: 'none',
+        boxShadow: 'none',
+      },
+
+      '& .MuiOutlinedInput-root .MuiSelect-customIcon': {
+        right: 0,
+      },
+
+      '& .MuiOutlinedInput-notchedOutline': {
+        border: 'none'
+      },
+
+      '& .MuiSelect-selectMenu': {
+        padding: '0 1.25rem 0 0',
+        height: 'auto',
+      },
+    },
+
+    '& .MuiListItem-secondaryAction': {
+      padding: 0,
+    },
+
+    '& .MuiListItemText-root': {
+      margin: 0,
+      display: 'flex',
+      alignItems: 'center',
+
+      '& .MuiTypography-root': {
+        fontWeight: 400,
+        fontSize: '0.8125rem',
+        lineHeight: '1.5rem',
+        letterSpacing: '-0.0025em',
+        margin: 0,
+        color: headerButtonBorderColor,
+
+        '&.MuiTypography-body2': {
+          color: textDisabled,
+          marginLeft: '0.3125rem'
+        },
+      },
+
+      '& + .MuiListItemText-root': {
+        flex: 'none'
+      },
+    },
+
+    '& .MuiListItemAvatar-root': {
+      minWidth: '0.0625rem',
+      paddingRight: '0.5rem',
+    },
+
+    '& .MuiListItem-root.Mui-disabled': {
+      opacity: 0.4,
+    },
+
+    '& .MuiAvatar-root': {
+      width: '1.5rem',
+      height: '1.5rem',
+    },
+
+
+  },
+
+  wrap: {
+    gap: '0.5rem',
+    '& .MuiButton-root': {
+      width: '5.625rem',
+      flexShrink: 0,
+    },
+  },
+}));
+
+function TabPanel(props) {
+  const { children, value, index, ...other } = props;
+
+  return (
+    <div
+      role="tabpanel"
+      hidden={value !== index}
+      id={`simple-tabpanel-${index}`}
+      aria-labelledby={`simple-tab-${index}`}
+      {...other}
+    >
+      {value === index && (
+        <>{props.children}</>
+      )}
+    </div>
+  );
+}
+
+TabPanel.propTypes = {
+  children: PropTypes.node,
+  index: PropTypes.any.isRequired,
+  value: PropTypes.any.isRequired,
+};
+
+function a11yProps(index) {
+  return {
+    id: `simple-tab-${index}`,
+    'aria-controls': `simple-tabpanel-${index}`,
+  };
+}
+
+export const ShareExperimentTabs = (props) => {
+  const classes = useStyles();
+  const { value, handleChange } = props;
+  const [userRole, setUserRole] = React.useState(userRoles[0]);
+
+  const handleSelect = (event) => {
+    setUserRole(event.target.value);
+  };
+
+  const userRoleSelection = (props) => {
+    return (
+      <FormControl variant="outlined" {...props}>
+        <Select
+          IconComponent={() => <img
+            className="MuiSelect-icon MuiSelect-customIcon"
+            src={DOWN}
+            alt="down"
+          />}
+          labelId="demo-simple-select-outlined-label"
+          id="demo-simple-select-outlined"
+          value={userRole}
+          onChange={handleSelect}
+        >
+          {
+            userRoles.map((role) => <MenuItem value={role}>{role}</MenuItem>)
+          }
+        </Select>
+      </FormControl>
+    )
+  }
+
+  return (
+    <>
+      <Tabs className={classes.tabs} value={value} onChange={handleChange}>
+        <Tab disableRipple label="Add collaborators" {...a11yProps(0)} />
+        <Tab disableRipple label="Publish in a team" {...a11yProps(1)} />
+        <Tab disableRipple label="Publish in Community" {...a11yProps(2)} />
+      </Tabs>
+
+      <Box px={2} py={3} className={classes.tabContent}>
+        <TabPanel value={props?.value} index={0}>
+          <Typography variant="body2">Experiment link</Typography>
+          <Box className={classes.copyLink} display="flex">
+            <Typography variant="caption">
+              app.salk-cord-atlas.com/experiment/122896674
+            </Typography>
+            <Button variant="contained" disableElevation>
+              Copy link
+            </Button>
+          </Box>
+
+          <Typography>
+            Only allowed collaborators will be able to open the experiment using the link.
+          </Typography>
+
+          <Box className={classes.collaborators}>
+            <Typography variant="body2">Collaborators</Typography>
+            <Box mb={3} display={'flex'} className={classes.wrap}>
+              <TextField
+                placeholder="Add an user with email address"
+                variant="outlined"
+              />
+              {userRoleSelection()}
+              <Button variant="contained" disableElevation>
+                Send Invite
+              </Button>
+            </Box>
+
+            <List>
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar src={USER} />
+                </ListItemAvatar>
+                <ListItemText primary="Ben Stern" secondary="(You)" />
+                <ListItemText primary="Owner" />
+              </ListItem>
+
+              <ListItem>
+                <ListItemAvatar>
+                  <Avatar src={USER} />
+                </ListItemAvatar>
+                <ListItemText primary="Ben Stern" />
+                {userRoleSelection()}
+              </ListItem>
+            </List>
+          </Box>
+        </TabPanel>
+        <TabPanel value={value} index={1}>
+          <Box className={classes.formGroup} mb={1}>
+            <Typography variant="body2">Team</Typography>
+            {userRoleSelection({fullWidth: true})}
+          </Box>
+          <Typography>
+            All members from this team will automatically have view-only access to this experiment. This experiment will be displayed in Teams section, and will be clonable by members of the team.
+          </Typography>
+        </TabPanel>
+        <TabPanel value={value} index={2}>
+          <Typography variant="body2">License</Typography>
+          <Typography>Creative Commons BY 4.0</Typography>
+          <Typography>
+            All members on the application, including ones outside your teams, will automatically have view-only access to this experiment. This experiment will be displayed in the Community, and will be clonable by all users.
+          </Typography>
+
+          <Button disableRipple>Learn More</Button>
+        </TabPanel>
+      </Box>
+    </>
+  );
+};

--- a/applications/salk-portal/src/components/home/Community.jsx
+++ b/applications/salk-portal/src/components/home/Community.jsx
@@ -202,7 +202,7 @@ const Community = (props) => {
         <Typography component="h2">Popular experiments</Typography>
         <Grid container item spacing={3}>
           {[1, 2, 3, 4].map( i => (
-            <ExperimentCard experiment={dummyExperiment} type={COMMUNITY_HASH} handleDialogToggle={props?.handleDialogToggle} handleExplorationDialogToggle={props?.handleExplorationDialogToggle} />
+            <ExperimentCard experiment={dummyExperiment} type={COMMUNITY_HASH} handleDialogToggle={props?.handleDialogToggle} handleExplorationDialogToggle={props?.handleExplorationDialogToggle} handleShareDialogToggle={props?.handleShareDialogToggle} handleShareMultipleDialogToggle={props?.handleShareMultipleDialogToggle} />
           ))}
         </Grid>
       </Box>
@@ -232,7 +232,7 @@ const Community = (props) => {
         <Typography component="h2">Last Published</Typography>
         <Grid container item spacing={3}>
           {[1, 2, 3, 4].map(i => (
-            <ExperimentCard experiment={dummyExperiment} type={COMMUNITY_HASH} handleDialogToggle={props?.handleDialogToggle} handleExplorationDialogToggle={props?.handleExplorationDialogToggle} />
+            <ExperimentCard experiment={dummyExperiment} type={COMMUNITY_HASH} handleDialogToggle={props?.handleDialogToggle} handleExplorationDialogToggle={props?.handleExplorationDialogToggle} handleShareDialogToggle={props?.handleShareDialogToggle} handleShareMultipleDialogToggle={props?.handleShareMultipleDialogToggle} />
           ))}
         </Grid>
       </Box>

--- a/applications/salk-portal/src/components/home/ExperimentCard.jsx
+++ b/applications/salk-portal/src/components/home/ExperimentCard.jsx
@@ -209,7 +209,7 @@ const useStyles = makeStyles(() => ({
 
 }));
 
-const ExperimentCard = ({experiment, type, handleDialogToggle, handleExplorationDialogToggle}) => {
+const ExperimentCard = ({experiment, type, handleDialogToggle, handleExplorationDialogToggle, handleShareDialogToggle, handleShareMultipleDialogToggle}) => {
   const classes = useStyles();
   const history = useHistory()
   const handleClick = () => {
@@ -257,10 +257,10 @@ const ExperimentCard = ({experiment, type, handleDialogToggle, handleExploration
           <ListItem>
             <ListItemText primary="Share" secondary={<ArrowRightIcon />} />
             <List component="nav" aria-label="secondary mailbox folders">
-              <ListItem button>
+              <ListItem button onClick={handleShareDialogToggle}>
                 <ListItemText primary="Share this experiment" />
               </ListItem>
-              <ListItem button>
+              <ListItem button onClick={handleShareMultipleDialogToggle}>
                 <ListItemText primary="Share multiple experiments" />
               </ListItem>
             </List>

--- a/applications/salk-portal/src/components/home/ExperimentList.jsx
+++ b/applications/salk-portal/src/components/home/ExperimentList.jsx
@@ -197,7 +197,7 @@ const ExperimentList = (props) => {
   }
 
   const tags = ["Project A", "Tag X", "Label 1"];
-  const { heading, description, type, infoIcon, handleDialogToggle, handleExplorationDialogToggle } = props;
+  const { heading, description, type, infoIcon, handleDialogToggle, handleExplorationDialogToggle, handleShareMultipleDialogToggle, handleShareDialogToggle } = props;
   const sortOptions = ["Alphabetical", "Date created", "Last viewed"];
   const orderOptions = ["Oldest first", "Newest first"];
   const dummyExperiment = {
@@ -334,7 +334,7 @@ const ExperimentList = (props) => {
       <Box p={5}>
         <Grid container item spacing={3}>
           {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map( i => (
-            <ExperimentCard experiment={dummyExperiment} type={type} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle}/>
+            <ExperimentCard experiment={dummyExperiment} type={type} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} handleShareDialogToggle={handleShareDialogToggle} handleShareMultipleDialogToggle={handleShareMultipleDialogToggle} />
             ))
           }
         </Grid>

--- a/applications/salk-portal/src/components/home/ShareExperiment.jsx
+++ b/applications/salk-portal/src/components/home/ShareExperiment.jsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import Modal from "../common/BaseDialog";
+import { ShareExperimentTabs } from "../common/ExperimentDialogs/ShareExperimentTabs";
+
+export const ShareExperimentDialog = (props) => {
+  const { open, handleClose } = props;
+  const [value, setValue] = React.useState(0);
+
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  const handleSalkTeam = () => {
+    console.log("Publish to Salk team")
+  };
+
+  const handleCommunity = () => {
+    console.log("Publish to Community")
+  };
+
+  return (
+    <Modal
+      dialogActions={value !== 0}
+      actionText={value === 1 ? "Publish to Salk team" : "Publish to Community" }
+      disableGutter
+      open={open}
+      handleClose={handleClose}
+      handleAction={value === 1 ? handleSalkTeam : handleCommunity}
+      title="Share"
+    >
+      <ShareExperimentTabs value={value} handleChange={handleChange}/>
+    </Modal>
+  );
+};

--- a/applications/salk-portal/src/components/home/ShareMultipleExperiment.jsx
+++ b/applications/salk-portal/src/components/home/ShareMultipleExperiment.jsx
@@ -4,15 +4,43 @@ import {
   makeStyles,
   FormControlLabel,
   Checkbox,
+  TextField
 } from "@material-ui/core";
 import Modal from "../common/BaseDialog";
 import CHECK_ICON from "../../assets/images/icons/checkbox.svg";
 import CHECKED_ICON from "../../assets/images/icons/checkbox-filled.svg";
 import { ShareExperimentTabs } from "../common/ExperimentDialogs/ShareExperimentTabs";
+import { headerBorderColor, headerBg, sidebarTextColor, secondaryColor } from "../../theme";
 
 const useStyles = makeStyles(() => ({
   checkboxGroup: {
     padding: '0.5rem 1rem 4.25rem 0.375rem',
+  },
+
+  searchExperiment: {
+    padding: '0 1rem',
+    boxShadow: `inset 0 -0.0625rem 0 ${headerBorderColor}`,
+    height: '2.75rem',
+    position: 'sticky',
+    top: 0,
+    backgroundColor: headerBg,
+    zIndex: 99,
+
+    '& .MuiInputBase-input': {
+      padding: 0,
+      height: '2.75rem',
+      fontWeight: 500,
+      fontSize: '0.75rem',
+      lineHeight: '1.0625rem',
+      letterSpacing: '0.005em',
+      color: secondaryColor,
+      '&:placeholder': {color: sidebarTextColor,},
+    },
+
+    '& .MuiInput-underline': {
+      '&::before': { display: 'none' },
+      '&::after': { display: 'none' },
+    },
   },
 }));
 
@@ -24,7 +52,7 @@ export const ShareMultipleExperimentDialog = (props) => {
   const handleChange = (event, newValue) => {
     setValue(newValue);
   };
-
+  const experiments = ["Exploration of the spinal cord", "Exploration of the spinal cord", "Exploration of the spinal cord"];
   return (
     <Modal
       dialogActions={!tabsView || (tabsView && value!== 0)}
@@ -36,53 +64,27 @@ export const ShareMultipleExperimentDialog = (props) => {
       title="Share multiple experiments"
     >
       {!tabsView ? (
-        <Box className={classes.checkboxGroup}>
-          <FormControlLabel
-            control={
-              <Checkbox
-                icon={<img src={CHECK_ICON} alt="" />}
-                checkedIcon={<img src={CHECKED_ICON} alt="" />}
-              />
+        <>
+          <Box className={classes.searchExperiment}>
+            <TextField fullWidth placeholder="Search for an experiment" />
+          </Box>
+          <Box className={classes.checkboxGroup}>
+            {
+              experiments.map((experiment, index) =>(
+                <FormControlLabel
+                  key={`${experiment}_${index}`}
+                  control={
+                    <Checkbox
+                      icon={<img src={CHECK_ICON} alt="" />}
+                      checkedIcon={<img src={CHECKED_ICON} alt="" />}
+                    />
+                  }
+                  label={experiment}
+                />
+              ))
             }
-            label="Exploration of the spinal cord"
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                icon={<img src={CHECK_ICON} alt="" />}
-                checkedIcon={<img src={CHECKED_ICON} alt="" />}
-              />
-            }
-            label="Exploration of the spinal cord"
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                icon={<img src={CHECK_ICON} alt="" />}
-                checkedIcon={<img src={CHECKED_ICON} alt="" />}
-              />
-            }
-            label="Exploration of the spinal cord"
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                icon={<img src={CHECK_ICON} alt="" />}
-                checkedIcon={<img src={CHECKED_ICON} alt="" />}
-              />
-            }
-            label="Exploration of the spinal cord"
-          />
-          <FormControlLabel
-            control={
-              <Checkbox
-                icon={<img src={CHECK_ICON} alt="" />}
-                checkedIcon={<img src={CHECKED_ICON} alt="" />}
-              />
-            }
-            label="Exploration of the spinal cord"
-          />
-        </Box>
+          </Box>
+        </>
       ) : (
          <ShareExperimentTabs value={value} handleChange={handleChange}/>
       )}

--- a/applications/salk-portal/src/components/home/ShareMultipleExperiment.jsx
+++ b/applications/salk-portal/src/components/home/ShareMultipleExperiment.jsx
@@ -1,0 +1,92 @@
+import * as React from "react";
+import {
+  Box,
+  makeStyles,
+  FormControlLabel,
+  Checkbox,
+} from "@material-ui/core";
+import Modal from "../common/BaseDialog";
+import CHECK_ICON from "../../assets/images/icons/checkbox.svg";
+import CHECKED_ICON from "../../assets/images/icons/checkbox-filled.svg";
+import { ShareExperimentTabs } from "../common/ExperimentDialogs/ShareExperimentTabs";
+
+const useStyles = makeStyles(() => ({
+  checkboxGroup: {
+    padding: '0.5rem 1rem 4.25rem 0.375rem',
+  },
+}));
+
+export const ShareMultipleExperimentDialog = (props) => {
+  const classes = useStyles();
+  const { open, handleClose } = props;
+  const [value, setValue] = React.useState(0);
+  const [tabsView, setTabsView] = React.useState(false);
+  const handleChange = (event, newValue) => {
+    setValue(newValue);
+  };
+
+  return (
+    <Modal
+      dialogActions={!tabsView || (tabsView && value!== 0)}
+      actionText={!tabsView ? "Next" : value === 1 ? "Publish to Salk team" :  "Publish to Community" }
+      disableGutter
+      open={open}
+      handleClose={handleClose}
+      handleAction={!tabsView ? () => setTabsView(true) : () => {}}
+      title="Share multiple experiments"
+    >
+      {!tabsView ? (
+        <Box className={classes.checkboxGroup}>
+          <FormControlLabel
+            control={
+              <Checkbox
+                icon={<img src={CHECK_ICON} alt="" />}
+                checkedIcon={<img src={CHECKED_ICON} alt="" />}
+              />
+            }
+            label="Exploration of the spinal cord"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                icon={<img src={CHECK_ICON} alt="" />}
+                checkedIcon={<img src={CHECKED_ICON} alt="" />}
+              />
+            }
+            label="Exploration of the spinal cord"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                icon={<img src={CHECK_ICON} alt="" />}
+                checkedIcon={<img src={CHECKED_ICON} alt="" />}
+              />
+            }
+            label="Exploration of the spinal cord"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                icon={<img src={CHECK_ICON} alt="" />}
+                checkedIcon={<img src={CHECKED_ICON} alt="" />}
+              />
+            }
+            label="Exploration of the spinal cord"
+          />
+          <FormControlLabel
+            control={
+              <Checkbox
+                icon={<img src={CHECK_ICON} alt="" />}
+                checkedIcon={<img src={CHECKED_ICON} alt="" />}
+              />
+            }
+            label="Exploration of the spinal cord"
+          />
+        </Box>
+      ) : (
+         <ShareExperimentTabs value={value} handleChange={handleChange}/>
+      )}
+
+    </Modal>
+  );
+};

--- a/applications/salk-portal/src/css/variables.less
+++ b/applications/salk-portal/src/css/variables.less
@@ -25,7 +25,7 @@
 @switchActiveColor: #7B61FF;
 @sidebarTextColor: rgba(255, 255, 255, 0.4);
 @sidebarBadgeBg: rgba(255, 255, 255, 0.1);
-@backdropBg: rgba(0,0,0,0.1);
+@backdropBg: rgba(0,0,0,0.4);
 @defaultChipBg: #026AA2;
 @primaryChipBg: #5925DC;
 @secondaryChipBg: #027A48;

--- a/applications/salk-portal/src/pages/HomePage.tsx
+++ b/applications/salk-portal/src/pages/HomePage.tsx
@@ -8,6 +8,8 @@ import Community from "../components/home/Community";
 import { EXPERIMENTS_HASH, SALK_TEAM, ACME_TEAM, COMMUNITY_HASH, SHARED_HASH } from "../constants";
 import { CloneExperimentDialog } from "../components/home/CloneExperimentDialog";
 import { ExplorationSpinalCordDialog } from "../components/home/ExplorationSpinalCordDialog";
+import { ShareExperimentDialog } from "../components/home/ShareExperiment";
+import { ShareMultipleExperimentDialog } from "../components/home/ShareMultipleExperiment";
 
 const useStyles = makeStyles(() => ({
   layoutContainer: {
@@ -53,31 +55,46 @@ export default (props: any) => {
   const handleExplorationDialogToggle = () => {
     setExplorationDialogOpen((prevOpen) => !prevOpen);
   };
+
+  const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
+
+  const handleShareDialogToggle = () => {
+    setShareDialogOpen((prevOpen) => !prevOpen);
+  };
+
+  const [shareMultipleDialogOpen, setShareMultipleDialogOpen] = React.useState(false);
+
+  const handleShareMultipleDialogToggle = () => {
+    setShareMultipleDialogOpen((prevOpen) => !prevOpen);
+  };
+
   return (
     <Box display="flex">
       <Sidebar executeScroll={(r: string) => executeScroll(r)} />
       <Box className={classes.layoutContainer}>
         <div ref={myRef} id={EXPERIMENTS_HASH}>
-          <ExperimentList heading={"My experiments"} description={"7 experiments"} type={EXPERIMENTS_HASH} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false} />
+          <ExperimentList heading={"My experiments"} description={"7 experiments"} type={EXPERIMENTS_HASH} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false} handleShareDialogToggle={handleShareDialogToggle} handleShareMultipleDialogToggle={handleShareMultipleDialogToggle}/>
         </div>
         <div ref={shared} id={SHARED_HASH}>
-          <ExperimentList heading={"Shared with me"} description={"28 experiments"} type={SHARED_HASH} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false} />
+          <ExperimentList heading={"Shared with me"} description={"28 experiments"} type={SHARED_HASH} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false} handleShareDialogToggle={handleShareDialogToggle} handleShareMultipleDialogToggle={handleShareMultipleDialogToggle} />
         </div>
         <div ref={salkteam} id={SALK_TEAM}>
-          <ExperimentList heading={"Salk Institute Team"} description={"19 experiments"} type={SALK_TEAM} handleDialogToggle={handleDialogToggle}handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={true} />
+          <ExperimentList heading={"Salk Institute Team"} description={"19 experiments"} type={SALK_TEAM} handleDialogToggle={handleDialogToggle}handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={true} handleShareDialogToggle={handleShareDialogToggle} handleShareMultipleDialogToggle={handleShareMultipleDialogToggle} />
         </div>
         <div ref={acmeteam} id={ACME_TEAM}>
-          <ExperimentList heading={"Acme Team"} description={"19 experiments"} type={ACME_TEAM} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false}/>
+          <ExperimentList heading={"Acme Team"} description={"19 experiments"} type={ACME_TEAM} handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} infoIcon={false}handleShareDialogToggle={handleShareDialogToggle} handleShareMultipleDialogToggle={handleShareMultipleDialogToggle} />
         </div>
         <Box p={5}>
           <div ref={communityRef} id={COMMUNITY_HASH}>
-            <Community handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} />
+            <Community handleDialogToggle={handleDialogToggle} handleExplorationDialogToggle={handleExplorationDialogToggle} handleShareDialogToggle={handleShareDialogToggle} handleShareMultipleDialogToggle={handleShareMultipleDialogToggle} />
           </div>
         </Box>
 
       </Box>
       <CloneExperimentDialog open={dialogOpen} handleClose={handleDialogToggle} user={props?.user} />
       <ExplorationSpinalCordDialog open={explorationDialogOpen} handleClose={handleExplorationDialogToggle} />
+      <ShareExperimentDialog open={shareDialogOpen} handleClose={handleShareDialogToggle} />
+      <ShareMultipleExperimentDialog open={shareMultipleDialogOpen} handleClose={handleShareMultipleDialogToggle} />
     </Box>
   )
 };

--- a/applications/salk-portal/src/theme.js
+++ b/applications/salk-portal/src/theme.js
@@ -167,7 +167,14 @@ const theme = {
         border: 'none !important',
         boxShadow: 'none !important'
       },
-      select: { "&:focus": { background: "none" } },
+      selectMenu: {
+        height: '2rem',
+        alignItems: 'center',
+        display: 'flex',
+      },
+      select: {
+        "&:focus": { backgroundColor: "none" }
+      },
     },
     MuiCard: { root: { flex: 1 } },
     MuiBottomNavigation: { root: { backgroundColor: bgRegular, marginBottom: 8, borderRadius: 4 } },
@@ -239,12 +246,16 @@ const theme = {
     },
     MuiMenuItem: {
       root: {
-        fontSize: '1em',
-        paddingTop: gutter / 2,
+        fontWeight: '500',
+        fontSize: '0.75rem',
+        lineHeight: '1.0625rem',
+        letterSpacing: '0.005em',
+        display: 'flex',
+        alignItems: 'center',
+        color: secondaryColor,
       },
       gutters: {
-        paddingLeft: gutter * 2,
-        paddingRight: gutter * 2
+        padding: '0.5rem 1rem',
       }
 
     },
@@ -306,23 +317,22 @@ const theme = {
       }
     },
     MuiTab: {
+      textColorInherit: {
+        opacity: '0.6',
+        color: secondaryColor,
+      },
       root: {
+        fontWeight: 600,
+        fontSize: '0.75rem',
         textTransform: 'none',
-        fontSize: '1.1rem',
-        fontWeight: 400,
-        padding: '0 0.5rem 0 0',
-        textDecoration: 'none',
-        border: 0,
-        minHeight: '1.25rem',
-        height: '1.25rem',
-        minWidth: '9.375rem !important',
-        textAlign: 'left',
-        '&:first-child': {
-          borderRight: `0.0625rem solid ${secondaryColor}`,
+        lineHeight: '1rem',
+        letterSpacing: '0.005em',
+        padding: 0,
+        minWidth: '0.0625rem !important',
+
+        '&:not(:first-child)': {
+          marginLeft: '1rem',
         },
-        '&:last-child': {
-          padding: '0 0 0 0.5rem',
-        }
       }
     },
     MuiToolbar: {
@@ -333,6 +343,11 @@ const theme = {
 
 
     MuiFormControlLabel: {
+      root: {
+        display: 'flex',
+        marginRight: 0,
+        marginLeft: 0,
+      },
       labelPlacementStart: {
         marginLeft: 0,
         marginRight: 0,
@@ -485,17 +500,17 @@ const theme = {
         boxShadow: `inset 0 0.0625rem 0 ${headerBorderColor}`,
 
         '& .MuiButton-root': {
-          flexGrow: 1,
-          marginRight: 0,
+          width: 'calc((100% - 0.5rem) / 2)',
+          margin: 0,
         },
       },
     },
 
     MuiDialogTitle: {
       root: {
-        padding: '0.125rem 0.25rem 0.125rem 1rem',
         fontWeight: 600,
         fontSize: '1rem',
+        padding: '0.125rem 0.25rem 0.125rem 1rem',
         boxShadow: `inset 0 -0.0625rem 0 ${headerBorderColor}`,
 
         '& .MuiTypography-root': {
@@ -541,7 +556,7 @@ const theme = {
         lineHeight: '1rem',
         order: 2,
         letterSpacing: '0.01em',
-        color: 'rgba(255, 255, 255, 0.4)',
+        color: sidebarTextColor,
       },
     },
     MuiBackdrop: {
@@ -577,6 +592,11 @@ const theme = {
     MuiOutlinedInput: {
       root: {
         borderRadius: '0.375rem',
+
+        '& .MuiSelect-customIcon': {
+          top: 'auto',
+          right: '0.625rem',
+        },
 
         '&.Mui-focused': {
           '& .MuiOutlinedInput-notchedOutline': {
@@ -707,6 +727,26 @@ const theme = {
       barColorPrimary: {
         backgroundColor: headerButtonBorderColor,
         borderRadius: '0.125rem',
+      },
+    },
+
+    MuiMenu: {
+      paper: {
+        transform: 'translateY(2.25rem) !important',
+        boxShadow: '0 0.75rem 2.5rem -0.25rem rgba(0, 0, 0, 0.3), 0 0.25rem 0.375rem -0.125rem rgba(0, 0, 0, 0.2)',
+        maxWidth: '10rem',
+        width: '100%',
+        border: `0.0625rem solid ${headerBorderColor}`,
+        background: headerBg,
+        borderRadius: '0.375rem',
+        padding: '0.75rem 0',
+      },
+    },
+
+    MuiList: {
+      padding: {
+        paddingTop: 0,
+        paddingBottom: 0,
       },
     },
   },


### PR DESCRIPTION
Closes #75 

Implemented solution: ... 
Added share modals UI
How to test this PR: ...

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [x] Screenshots of the changes
- [ ] Explanatory video/animated gif
<img width="533" alt="Screen Shot 2022-04-05 at 2 55 57 PM" src="https://user-images.githubusercontent.com/71261494/161758466-50edd19c-0c23-409b-a635-a1763e781f7d.png">
<img width="544" alt="Screen Shot 2022-04-05 at 2 55 49 PM" src="https://user-images.githubusercontent.com/71261494/161758491-a163a6d7-7f12-4387-a621-d3a435423663.png">
<img width="530" alt="Screen Shot 2022-04-05 at 2 52 54 PM" src="https://user-images.githubusercontent.com/71261494/161758493-4a625518-5811-4da3-842a-acd80b8e0ee3.png">

