### PR TITLE
#94 chore: Add camera reset on subdivision changes

### DIFF
--- a/applications/salk-portal/src/components/ExperimentViewer.tsx
+++ b/applications/salk-portal/src/components/ExperimentViewer.tsx
@@ -88,7 +88,6 @@ const getColorOpacityPair = (color: string, opacity: number) => {
 class ExperimentViewer extends Component {
     private scene: THREE.Scene;
     private readonly populationsMap: {};
-
     // @ts-ignore
     constructor(props) {
         super(props);
@@ -231,7 +230,10 @@ class ExperimentViewer extends Component {
     render() {
         // @ts-ignore
         const {classes} = this.props
-        const {cameraOptions, captureOptions} = getDefaultOptions()
+        // tslint:disable-next-line:prefer-const
+        let {cameraOptions, captureOptions} = getDefaultOptions()
+        // @ts-ignore
+        cameraOptions = {...cameraOptions, reset: this.props.shouldCameraReset}
         // @ts-ignore
         const canvasData: any = mapToCanvasData(this.getInstancesToShow())
         return (<div className={classes.canvasContainer}>

--- a/applications/salk-portal/src/pages/ExperimentsPage.tsx
+++ b/applications/salk-portal/src/pages/ExperimentsPage.tsx
@@ -7,7 +7,7 @@ import {getLayoutManagerInstance} from "@metacell/geppetto-meta-client/common/la
 // @ts-ignore
 import {WidgetStatus} from "@metacell/geppetto-meta-client/common/layout/model";
 // @ts-ignore
-import {addWidget, updateWidget, deleteWidget} from '@metacell/geppetto-meta-client/common/layout/actions';
+import {addWidget, deleteWidget, updateWidget} from '@metacell/geppetto-meta-client/common/layout/actions';
 // @ts-ignore
 import Loader from '@metacell/geppetto-meta-ui/loader/Loader'
 
@@ -212,16 +212,24 @@ const ExperimentsPage = () => {
         }
     }, [experiment])
 
-    useEffect(() => {
-        const subdivisionsSet = new Set(Object.keys(subdivisions).filter(sId => subdivisions[sId].selected))
-        // @ts-ignore
+    function getSelectedSubdivisionsSet() {
+        return new Set(Object.keys(subdivisions).filter(sId => subdivisions[sId].selected));
+    }
 
+    // TODO: Handle selectedAtlas changes
+
+    useEffect(() => {
+        const subdivisionsSet = getSelectedSubdivisionsSet()
         if (widgetsReady) {
-            dispatch(updateWidget(CanvasWidget(selectedAtlas, subdivisionsSet, getActivePopulations())))
+            dispatch(updateWidget(CanvasWidget(selectedAtlas, subdivisionsSet, getActivePopulations(), true)))
         }
-    }, [subdivisions, populations, selectedAtlas])
+    }, [subdivisions])
 
     useEffect(() => {
+        const subdivisionsSet = getSelectedSubdivisionsSet();
+        if (widgetsReady) {
+            dispatch(updateWidget(CanvasWidget(selectedAtlas, subdivisionsSet, getActivePopulations(), false)))
+        }
         handleOverlays(new Set([OverlaysDependencies.POPULATIONS]))
     }, [populations])
 

--- a/applications/salk-portal/src/widgets.ts
+++ b/applications/salk-portal/src/widgets.ts
@@ -1,10 +1,10 @@
 import {AtlasChoice} from "./utilities/constants";
 // @ts-ignore
 import {WidgetStatus} from "@metacell/geppetto-meta-client/common/layout/model";
-import Cell from "./models/Cell";
 import {Population} from "./apiclient/workspaces";
 
-export const CanvasWidget = (selectedAtlas: AtlasChoice, activeSubdivisions: Set<string>, activePopulations: any) => {
+export const CanvasWidget = (selectedAtlas: AtlasChoice, activeSubdivisions: Set<string>, activePopulations: any,
+                             shouldCameraReset: boolean = false) => {
     return {
         id: 'canvasWidget',
         name: "Spinal Cord Atlas",
@@ -16,6 +16,7 @@ export const CanvasWidget = (selectedAtlas: AtlasChoice, activeSubdivisions: Set
             selectedAtlas,
             activeSubdivisions,
             activePopulations,
+            shouldCameraReset
         }
     }
 };


### PR DESCRIPTION
Closes #94

Implemented solution: 
Resets camera on subdivision changes

Showcasing video:
https://github.com/MetaCell/salk-interactive-atlas/issues/94#issuecomment-1121339324

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
