### PR TITLE
Feature/141

### DIFF
--- a/applications/salk-portal/src/pages/ExperimentsPage.tsx
+++ b/applications/salk-portal/src/pages/ExperimentsPage.tsx
@@ -158,11 +158,12 @@ const ExperimentsPage = () => {
 
     useInterval(() => {
         const fetchData = async () => {
+            // @ts-ignore
             const response = await api.retrieveExperiment(params.id)
             const fetchedExperiment = response.data;
             const cells = await Promise.all(fetchedExperiment.populations.map(async (p) => {
                 if (p.status !== POPULATION_FINISHED_STATE) return [];
-                const existingPopulation = experiment.populations.find(e => e.id === p.id)
+                const existingPopulation = experiment.populations.find((e: ExperimentPopulationsInner) => e.id === p.id)
                 if (existingPopulation !== undefined && typeof existingPopulation.cells !== "string" && existingPopulation.cells.length > 0) return existingPopulation.cells
                 try {
                     return await getCells(p);
@@ -172,7 +173,7 @@ const ExperimentsPage = () => {
             }));
             let shouldUpdateExperiment = false;
             fetchedExperiment.populations.forEach((p, i) => {
-                const existingPopulation = experiment.populations.find(e => e.id === p.id)
+                const existingPopulation = experiment.populations.find((e: ExperimentPopulationsInner) => e.id === p.id)
                 if (existingPopulation === undefined || typeof existingPopulation.cells === "string" || existingPopulation.cells.length === 0) {
                     // previous population cells !== new population cells --> update the experiment data
                     shouldUpdateExperiment = true;
@@ -194,6 +195,7 @@ const ExperimentsPage = () => {
 
     useEffect(() => {
         const fetchData = async () => {
+            // @ts-ignore
             const response = await api.retrieveExperiment(params.id)
             const data = response.data;
             const cells = await Promise.all(data.populations.map(async (p) => {

--- a/applications/salk-portal/src/utils.ts
+++ b/applications/salk-portal/src/utils.ts
@@ -9,6 +9,6 @@ export function getBaseDomain() {
   return window.location.host.includes('www.') ? window.location.host.split('.').slice(1).join('.') : window.location.host  // remove the first part of the hostname
 }
 
-export function getDateFromDateTime(date: String) {
+export function getDateFromDateTime(date: string) {
   return date ? date?.split(' ')[0] : date;
 }


### PR DESCRIPTION
Closes #141 

Implemented solution: 
Uses regular expressions to split the cells file data

How to test this PR:
[transformed_cells (1).csv](https://github.com/MetaCell/salk-interactive-atlas/files/8950880/transformed_cells.1.csv) was generating only 1 cell (see issue) now it generates all the expected cells:
![image](https://user-images.githubusercontent.com/19196034/174855373-e653555c-9683-44f1-b172-9810aed4e7a3.png)



### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
