### PR TITLE
Feature/190 bonus

### DIFF
--- a/applications/portal/backend/api/constants.py
+++ b/applications/portal/backend/api/constants.py
@@ -21,6 +21,11 @@ class LaminasImages(Enum):
     DASHED = "dashed"
 
 
+class GridImages(Enum):
+    COMPLETE = "complete"
+    FRAME = "frame"
+
+
 FULLY_OPAQUE = 255
 HALF_OPAQUE = 128
 

--- a/applications/portal/backend/api/helpers/density_map/generate_image.py
+++ b/applications/portal/backend/api/helpers/density_map/generate_image.py
@@ -4,7 +4,7 @@ from PIL import Image
 from typing import Tuple
 from api.constants import FULLY_OPAQUE, WHITE
 from api.helpers.density_map.common_density_helpers import get_subdivision_limits, get_img_array_offset
-from api.helpers.density_map.grid_creator import get_grid_image
+from api.helpers.density_map.grid_creator import get_grid_images
 from api.helpers.exceptions import NoImageDataError
 from api.helpers.ICustomAtlas import ICustomAtlas
 from api.helpers.image_manipulation import black_to_transparent, get_image_from_array
@@ -163,8 +163,8 @@ def generate_canal_image(bg_atlas: ICustomAtlas, subdivision: str) -> (np.array,
     )
 
 
-def generate_grid_image(bg_atlas: ICustomAtlas, subdivision: str) -> (np.array, Image):
-    return get_grid_image(bg_atlas, subdivision)
+def generate_grid_images(bg_atlas: ICustomAtlas, subdivision: str) -> (Image, Image):
+    return get_grid_images(bg_atlas, subdivision)
 
 
 def generate_lamina_image(

--- a/applications/portal/backend/api/helpers/density_map/grid_creator.py
+++ b/applications/portal/backend/api/helpers/density_map/grid_creator.py
@@ -20,9 +20,9 @@ from workspaces.settings import (
 )
 
 
-def get_grid_image(
+def get_grid_images(
         bg_atlas: ICustomAtlas, subdivision: str
-) -> Image:
+) -> (Image, Image):
     w, h = get_grid_dimensions(bg_atlas)
 
     fig, ax = plt.subplots()
@@ -32,7 +32,6 @@ def get_grid_image(
     x_shape, y_shape = _set_size(w, h, ax)
 
     resolution_z = 1 / (bg_atlas.resolution[0] * UM_TO_MM)
-
 
     # calculates ratio from image size to atlas size
     ratio_x = w / x_shape
@@ -80,13 +79,18 @@ def get_grid_image(
         item.set_fontsize(GRID_FONT_SIZE)
 
     plt.grid(False)
-    img = fig_to_img(fig)
+    frame_img = fig_to_img(fig)
+    plt.grid(True)
+    complete_img = fig_to_img(fig)
 
-    # Corrects image alignment by adding a constant amount of padding to the image
-    shifted_image = _add_margin(
-        img, 0, GRID_CONSTANT_RIGHT_OFFSET, GRID_CONSTANT_BOTTOM_OFFSET, 0
+    # Corrects images alignment by adding a constant amount of padding to the image
+    frame_shifted_image = _add_margin(
+        frame_img, 0, GRID_CONSTANT_RIGHT_OFFSET, GRID_CONSTANT_BOTTOM_OFFSET, 0
     )
-    return shifted_image
+    complete_shifted_image = _add_margin(
+        complete_img, 0, GRID_CONSTANT_RIGHT_OFFSET, GRID_CONSTANT_BOTTOM_OFFSET, 0
+    )
+    return frame_shifted_image, complete_shifted_image
 
 
 def get_grid_dimensions(bg_atlas: ICustomAtlas, tick_step: float = GRID_TICK_STEP, tolerance: float = 0.1) -> \

--- a/applications/portal/backend/api/management/commands/generate_grid_images.py
+++ b/applications/portal/backend/api/management/commands/generate_grid_images.py
@@ -1,10 +1,10 @@
 from django.core.management.base import BaseCommand
 
 from api.helpers.atlas import get_bg_atlas, get_subdivisions
-from api.helpers.density_map.generate_image import generate_grid_image
+from api.helpers.density_map.generate_image import generate_grid_images
 from api.helpers.exceptions import NoImageDataError
 from api.management.utilities import get_valid_atlases
-from api.services.atlas_service import save_grid_image, save_grid_metadata
+from api.services.atlas_service import save_grid_images, save_grid_metadata
 
 
 class Command(BaseCommand):
@@ -23,15 +23,15 @@ class Command(BaseCommand):
                 continue
             bg_atlas = get_bg_atlas(atlas_id)
             subdivisions = get_subdivisions(bg_atlas)
-            img = None
+            frame_img = None
             for s in subdivisions:
                 try:
-                    img = generate_grid_image(bg_atlas, s)
+                    frame_img, complete_img = generate_grid_images(bg_atlas, s)
                 except NoImageDataError:
                     continue
-                save_grid_image(img, s)
-            if img:
-                w, h = img.size
+                save_grid_images(frame_img, complete_img, s)
+            if frame_img:
+                w, h = frame_img.size
                 metadata = {
                     'width': w,
                     'height': h

--- a/applications/portal/backend/api/services/atlas_service.py
+++ b/applications/portal/backend/api/services/atlas_service.py
@@ -1,6 +1,7 @@
 import json
 import os
 
+from api.constants import GridImages
 from api.services.filesystem_service import create_dir
 from workspaces.settings import ANNOTATIONS_PATH, CANAL_PATH, GRID_PATH, LAMINAS_PATH
 
@@ -13,8 +14,9 @@ def save_canal_image(img, subdivision: str):
     return save_image(img, CANAL_PATH, subdivision)
 
 
-def save_grid_image(img, subdivision: str):
-    return save_image(img, GRID_PATH, subdivision)
+def save_grid_images(frame_img, complete_img, subdivision: str):
+    save_image(frame_img, os.path.join(GRID_PATH, GridImages.FRAME.value), subdivision)
+    save_image(complete_img, os.path.join(GRID_PATH, GridImages.COMPLETE.value), subdivision)
 
 
 def save_laminas_json(laminas_metadata: dict):

--- a/applications/portal/frontend/src/components/viewers/twoD/TwoDViewer.tsx
+++ b/applications/portal/frontend/src/components/viewers/twoD/TwoDViewer.tsx
@@ -15,10 +15,9 @@ import {
 } from "@material-ui/core";
 import {Population} from "../../../apiclient/workspaces";
 import {
-    AtlasChoice, CANVAS_HEIGHT, CANVAS_WIDTH,
-    CAUDAL,
+    AtlasChoice, CAUDAL,
     DensityImages,
-    DensityMapTypes, LaminaImageTypes,
+    DensityMapTypes, GridTypes, LaminaImageTypes,
     NEURONAL_LOCATIONS_ID,
     OVERLAYS, PROBABILITY_MAP_ID,
     RequestState,
@@ -191,6 +190,7 @@ const TwoDViewer = (props: {
     const [laminaPopoverAnchorEl, setLaminaPopoverAnchorEl] = React.useState(null);
     const [selectedLaminaPopoverId, setSelectedLaminaPopoverId] = React.useState(null);
     const [laminaType, setLaminaType] = React.useState(LaminaImageTypes.FILLED);
+    const [gridType, setGridType] = React.useState(GridTypes.FRAME);
     const [laminaBaseColor, setLaminaBaseColor] = React.useState(DARK_GREY_SHADE);
     const [isSnackbarOpen, setIsSnackbarOpen] = React.useState(false);
     const [showSnackbar, setShowSnackbar] = React.useState(true);
@@ -308,11 +308,10 @@ const TwoDViewer = (props: {
 
 
         // Draw grid
-        const grid = atlas.getImageSrc(DensityImages.GRID, segments[selectedValueIndex])
+        const grid = atlas.getGridSrc(segments[selectedValueIndex], gridType)
         if (grid) {
             drawImage(canvas, grid)
         }
-
 
         // Draw Annotation (Grey Matter and White Matter)
         const background = atlas.getImageSrc(DensityImages.ANNOTATION, segments[selectedValueIndex])
@@ -413,7 +412,7 @@ const TwoDViewer = (props: {
 
     useEffect(() => {
         draw().catch(console.error)
-    }, [content, laminas, laminaType])
+    }, [content, laminas, laminaType, gridType])
 
     useEffect(() => {
         setIsComponentReady(true)
@@ -486,6 +485,12 @@ const TwoDViewer = (props: {
         // @ts-ignore
         setLaminaType(value)
     }
+
+    const handleGridTypeChange = (value: string) => {
+        setIsDrawing(true)
+        // @ts-ignore
+        setGridType(value);
+    };
 
     const handleLaminaBaseColorChange = (hexColor: string) => {
         setLaminaBaseColor(hexColor)
@@ -646,6 +651,19 @@ const TwoDViewer = (props: {
                             checked={overlaysSwitchState[oId]}
                         />
                     )}
+                    <FormControl className={`${classes.dropdownContainer}`}>
+                        <Select
+                            className={`${classes.menuFontSize}`}
+                            disableUnderline={true}
+                            value={gridType}
+                            onChange={(event) => handleGridTypeChange(event.target.value)}
+                            MenuProps={{classes: {paper: classes.selectMenu}}}
+                        >
+                            {Object.values(GridTypes).map((type, idx) =>
+                                <MenuItem key={type} value={type}> {type.value} </MenuItem>
+                            )}
+                        </Select>
+                    </FormControl>
                 </Popover>
                 <Snackbar
                     open={isSnackbarOpen}

--- a/applications/portal/frontend/src/models/Atlas.ts
+++ b/applications/portal/frontend/src/models/Atlas.ts
@@ -1,6 +1,6 @@
 import AtlasInstance from "./AtlasInstance"
 import AtlasSegment from "./AtlasSegment"
-import {AtlasChoice, DensityImages, LaminaImageTypes} from "../utilities/constants";
+import {AtlasChoice, DensityImages, GridTypes, LaminaImageTypes} from "../utilities/constants";
 import AtlasLamina from "./AtlasLamina";
 import {shadeHexColor} from "../utilities/functions";
 import Dimensions from "./Dimensions";
@@ -64,6 +64,17 @@ export default class Atlas {
     getLaminaSrc(laminaName: string, segment: string, type: LaminaImageTypes) {
         try {
             return require("../assets/atlas/" + this.id + '/laminas/' + laminaName + '/' + type + '/' + segment + ".png").default
+        } catch (e) {
+            return null
+        }
+    }
+
+    getGridSrc(segment: string, gridType: { folder: string; }) {
+        if (gridType.folder === null){
+            return null
+        }
+        try {
+            return require("../assets/atlas/" + this.id + '/grid/' + gridType.folder + '/' + segment + ".png").default
         } catch (e) {
             return null
         }

--- a/applications/portal/frontend/src/service/CanvasService.ts
+++ b/applications/portal/frontend/src/service/CanvasService.ts
@@ -1,57 +1,63 @@
 import {hexToRgb} from "../utilities/functions";
 
-export const drawImage = (canvas: { getContext: (arg0: string) => any; width: number; height: number; } , src: string) => {
+export function drawImage(canvas: { getContext: (arg0: string) => any; width: number; height: number }, img: HTMLImageElement) {
     const ctx = canvas.getContext('2d')
-    const img = new Image();
-    img.onload = () => {
-        ctx.drawImage(img, canvas.width / 2 - img.width / 2,
-            canvas.height / 2 - img.height / 2);
-    };
-    img.src = src
+
+    ctx.drawImage(img, canvas.width / 2 - img.width / 2,
+        canvas.height / 2 - img.height / 2);
 }
+
 
 export const drawColoredImage = (canvas: { getContext: (arg0: string) => any; width: number; height: number; },
                                  hCanvas: { getContext: (arg0: string) => any; width: any; height: any; },
-                                 src: string, color: any) => {
+                                 img: HTMLImageElement, color: string) => {
 
-   return new Promise(resolve => {
-
-
-    const img = new Image();
     const ctx = canvas.getContext('2d')
     const hctx = hCanvas.getContext('2d')
     const colorRGB = hexToRgb(color)
 
-    img.onload = () => {
-        if (colorRGB) {
-            clearCanvas(hCanvas)
-            hctx.drawImage(img, hCanvas.width / 2 - img.width / 2,
-                hCanvas.height / 2 - img.height / 2);
-            const imageData = hctx.getImageData(0, 0, hCanvas.width, hCanvas.height);
-            const data = imageData.data;
+    if (colorRGB) {
+        clearCanvas(hCanvas)
+        hctx.drawImage(img, hCanvas.width / 2 - img.width / 2,
+            hCanvas.height / 2 - img.height / 2);
+        const imageData = hctx.getImageData(0, 0, hCanvas.width, hCanvas.height);
+        const data = imageData.data;
 
-            const A = 4
-            for (let i = 0; i < data.length; i++) {
-                const opacityIndex = i * A - 1;
-                if (data[opacityIndex] === 0) {
-                    continue
-                }
-                data[opacityIndex - 3] = colorRGB.r
-                data[opacityIndex - 2] = colorRGB.g
-                data[opacityIndex - 1] = colorRGB.b
+        const A = 4
+        for (let i = 0; i < data.length; i++) {
+            const opacityIndex = i * A - 1;
+            if (data[opacityIndex] === 0) {
+                continue
             }
-            hctx.putImageData(imageData, 0, 0);
-
-            ctx.drawImage(hCanvas, canvas.width / 2 - hCanvas.width / 2,
-                canvas.height / 2 - hCanvas.height / 2)
-            resolve(true)
+            data[opacityIndex - 3] = colorRGB.r
+            data[opacityIndex - 2] = colorRGB.g
+            data[opacityIndex - 1] = colorRGB.b
         }
-    };
-    img.src = src
-   })
+        hctx.putImageData(imageData, 0, 0);
+
+        ctx.drawImage(hCanvas, canvas.width / 2 - hCanvas.width / 2,
+            canvas.height / 2 - hCanvas.height / 2)
+    }
 }
 
 export const clearCanvas = (canvas: { getContext: (arg0: string) => any; width: any; height: any; }) => {
     const ctx = canvas.getContext('2d')
     ctx.clearRect(0, 0, canvas.width, canvas.height);
+}
+
+
+export const loadImages = (imagesToLoad: any[]) => {
+    const promises = []
+    for (const itl of imagesToLoad) {
+        promises.push(
+            new Promise((resolve, reject) => {
+                const img = new Image();
+                img.src = itl.src;
+                img.addEventListener('load', () => {
+                    resolve({img, draw: itl.draw});
+                });
+            })
+        )
+    }
+    return promises
 }

--- a/applications/portal/frontend/src/utilities/constants.ts
+++ b/applications/portal/frontend/src/utilities/constants.ts
@@ -21,12 +21,10 @@ export const COMMUNITY_HASH = 'community';
 
 export const PROBABILITY_MAP_ID = 'probabilityMap'
 export const NEURONAL_LOCATIONS_ID = 'neuronalLocations'
-export const GRID_VIEW = 'grid view'
 
 export const OVERLAYS = {
     [PROBABILITY_MAP_ID]: new OverlayMetadata(PROBABILITY_MAP_ID, "Probability Map"),
     [NEURONAL_LOCATIONS_ID]:  new OverlayMetadata(NEURONAL_LOCATIONS_ID, "Neuronal Locations"),
-    [GRID_VIEW]:  new OverlayMetadata(GRID_VIEW, "Grid"),
 } as any
 
 export enum RequestState {
@@ -60,4 +58,10 @@ export enum LaminaImageTypes {
     FILLED = "filled",
     CONTOUR = "contour",
     DASHED = "dashed",
+}
+
+export const GridTypes = {
+    OFF : {value: "Grid Off", folder: ''},
+    FRAME : {value: "Grid Frame", folder: 'frame'},
+    COMPLETE : {value: "Complete Grid", folder: 'complete'},
 }


### PR DESCRIPTION
Closes #190

Implemented solution: 
- Generates two grid images in the backend (frame and complete grid)
- Adds select button to the UI with 3 options (off, frame, complete)
- Refactors drawing strategy to fix inconsistent z-order issue (now we first load all images and only then draw)

How to test this PR: 


https://user-images.githubusercontent.com/19196034/187905176-1252a831-292f-4088-b06e-c8558c4a3c5c.mp4



### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
