### PR TITLE
#202 feat: Replace mocked canal data with real one

### DIFF
--- a/applications/portal/backend/api/helpers/bg_atlasapi_wrapper.py
+++ b/applications/portal/backend/api/helpers/bg_atlasapi_wrapper.py
@@ -23,10 +23,7 @@ class SalkAtlas(ICustomAtlas):
         """
         Generates an image volume of the central canal
         """
-        # TODO: Remove uncomment code when no longer in need of mocked data and uncomment commented return
-        canal = self.get_image_volume(self.structures["CC"]["id"])
-        return np.repeat(canal[0][np.newaxis, :, :], 790, axis=0)
-        # return self.get_image_volume(self.structures["CC"]["id"])
+        return self.get_image_volume(self.structures["CC"]["id"])
 
     def get_image_volume(self, region_key):
         """


### PR DESCRIPTION
Closes #202 

Implemented solution: 
- Updates salk atlas with new annotation
- Replaces use of mocked canal data with data from the atlas.annotation

How to test this PR: 
- See if canal data differs between segments
![image](https://user-images.githubusercontent.com/19196034/187933233-276142f4-3a2e-4112-a23b-1eee5f40d915.png)
![image](https://user-images.githubusercontent.com/19196034/187933197-5b94fa5d-fe93-48b3-be30-dc4a86304212.png)


### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
