### PR TITLE
#199 fix: Update segments limits and ranges inclusion logic

### DIFF
--- a/applications/portal/frontend/src/assets/atlas/salk_cord_10um/atlas_segments.json
+++ b/applications/portal/frontend/src/assets/atlas/salk_cord_10um/atlas_segments.json
@@ -1,47 +1,47 @@
 [
   {
-    "Start":370,
-    "End":459,
-    "Segment":"C5"
+    "Start": 730,
+    "End": 790,
+    "Segment": "T1"
   },
   {
-    "Start":730,
-    "End":779,
-    "Segment":"T1"
+    "Start": 460,
+    "End": 550,
+    "Segment": "C6"
   },
   {
-    "Start":640,
-    "End":729,
-    "Segment":"C8"
+    "Start": 640,
+    "End": 730,
+    "Segment": "C8"
   },
   {
-    "Start":550,
-    "End":639,
-    "Segment":"C7"
+    "Start": 370,
+    "End": 460,
+    "Segment": "C5"
   },
   {
-    "Start":0,
-    "End":79,
-    "Segment":"C1"
+    "Start": 70,
+    "End": 170,
+    "Segment": "C2"
   },
   {
-    "Start":80,
-    "End":169,
-    "Segment":"C2"
+    "Start": 0,
+    "End": 70,
+    "Segment": "C1"
   },
   {
-    "Start":170,
-    "End":269,
-    "Segment":"C3"
+    "Start": 170,
+    "End": 270,
+    "Segment": "C3"
   },
   {
-    "Start":460,
-    "End":549,
-    "Segment":"C6"
+    "Start": 270,
+    "End": 370,
+    "Segment": "C4"
   },
   {
-    "Start":270,
-    "End":369,
-    "Segment":"C4"
+    "Start": 550,
+    "End": 640,
+    "Segment": "C7"
   }
 ]

--- a/applications/portal/frontend/src/models/Range.ts
+++ b/applications/portal/frontend/src/models/Range.ts
@@ -8,7 +8,7 @@ export default class Range{
     }
 
     public includes(num: number) : boolean{
-        return num >= this.start && num <= this.end
+        return num >= this.start && num < this.end
     }
 
     public setStart(start: number){


### PR DESCRIPTION
Closes #199 

Implemented solution: 
- Updates segments limits
- Updates ranges inclusion logic (lower limit is the inclusive one)

How to test this PR: 

No C1 cells in neither of the viewers:

![image](https://user-images.githubusercontent.com/19196034/192776736-f9702386-6c25-40ba-9cb4-2107d49021f7.png)


### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope

PS: With the latest cordmap version V2b_PKD2L1_Cord1 doesn't contain cells on C1 nor C2:
![image](https://user-images.githubusercontent.com/19196034/192777530-a1c48bdf-bf7c-40ef-88e2-8903fcb4dabb.png)
The tests for this PR had to be made with the cordmap version present in dev at the time of writing
