### PR TITLE
#233 feat: Add coming soon messages

### DIFF
--- a/applications/portal/frontend/src/components/AboutDialog.tsx
+++ b/applications/portal/frontend/src/components/AboutDialog.tsx
@@ -105,6 +105,7 @@ export const AboutDialog = (props: any) => {
                         <Link href={'https://www.nih.gov/'} target={'_blank'}>Learn more about NIH</Link>
                     </Box>
                     <Divider/>
+                    <Typography>v1.0.0-beta.1</Typography>
                     <Link href={'https://www.metacell.us/'} target={'_blank'}>
                         <img src={METACELL} alt={"Powered by MetaCell"}/>
                     </Link>

--- a/applications/portal/frontend/src/components/ExplorerSidebar.jsx
+++ b/applications/portal/frontend/src/components/ExplorerSidebar.jsx
@@ -22,7 +22,7 @@ import TEAMS from "../assets/images/icons/teams.svg";
 import COMMUNITY from "../assets/images/icons/community.svg";
 import HELP from "../assets/images/icons/help.svg";
 import UP_ICON from "../assets/images/icons/up.svg";
-import { EXPERIMENTS_HASH, SALK_TEAM, ACME_TEAM, COMMUNITY_HASH, SHARED_HASH } from "../utilities/constants";
+import {EXPERIMENTS_HASH, SALK_TEAM, ACME_TEAM, COMMUNITY_HASH, SHARED_HASH, COMING_SOON} from "../utilities/constants";
 import {AboutDialog} from "./AboutDialog";
 
 const useStyles = makeStyles({
@@ -171,7 +171,7 @@ function ListItemLink(props) {
 const Sidebar = (props) => {
   const classes = useStyles();
   const {experiments} = props;
-  const [open, setOpen] = React.useState(true);
+  const [open, setOpen] = React.useState(false);
   const [dialogOpen, setDialogOpen] = React.useState(false);
 
 
@@ -210,14 +210,14 @@ const Sidebar = (props) => {
           <ListItemIcon>
             <img src={SHARED} alt="Shared" />
           </ListItemIcon>
-          <ListItemText primary="Shared with me" />
+          <ListItemText primary={`Shared with me\n${COMING_SOON}`} />
         </ListItemLink>
 
         <ListItem button onClick={handleClick}>
           <ListItemIcon>
             <img src={TEAMS} alt="Teams" />
           </ListItemIcon>
-          <ListItemText primary="Teams" />
+          <ListItemText primary={`Teams ${COMING_SOON}`}/>
           <img src={UP_ICON} className={open ? classes.rotate : ''} alt="arrow" />
         </ListItem>
         <Collapse in={open} timeout="auto" unmountOnExit>
@@ -241,13 +241,13 @@ const Sidebar = (props) => {
           <ListItemIcon>
             <img src={COMMUNITY} alt="Community" />
           </ListItemIcon>
-          <ListItemText primary="Community" />
+          <ListItemText primary={`Community ${COMING_SOON}`}/>
         </ListItemLink>
         <ListItemLink href="#simple-list">
           <ListItemIcon>
             <img src={HELP} alt="help" />
           </ListItemIcon>
-          <ListItemText primary="Help Center" />
+          <ListItemText primary={`Help Center ${COMING_SOON}`} />
         </ListItemLink>
       </List>
 

--- a/applications/portal/frontend/src/components/ExplorerSidebar.jsx
+++ b/applications/portal/frontend/src/components/ExplorerSidebar.jsx
@@ -206,27 +206,27 @@ const Sidebar = (props) => {
           <Badge badgeContent={experiments.length} />
         </ListItemLink>
 
-        <ListItemLink href="#shared" onClick={() => props.executeScroll(SHARED_HASH)} selected={hash === `#${SHARED_HASH}`}>
+        <ListItemLink disabled href="#shared" onClick={() => props.executeScroll(SHARED_HASH)} selected={hash === `#${SHARED_HASH}`}>
           <ListItemIcon>
             <img src={SHARED} alt="Shared" />
           </ListItemIcon>
-          <ListItemText primary={`Shared with me\n${COMING_SOON}`} />
+          <ListItemText primary={`Shared with me`} />
         </ListItemLink>
 
         <ListItem button onClick={handleClick}>
           <ListItemIcon>
             <img src={TEAMS} alt="Teams" />
           </ListItemIcon>
-          <ListItemText primary={`Teams ${COMING_SOON}`}/>
+          <ListItemText primary={`Teams`}/>
           <img src={UP_ICON} className={open ? classes.rotate : ''} alt="arrow" />
         </ListItem>
         <Collapse in={open} timeout="auto" unmountOnExit>
           <List component="div" disablePadding>
-            <ListItemLink href="#salkteam" onClick={() => props.executeScroll(SALK_TEAM)} selected={hash === `#${SALK_TEAM}`}>
+            <ListItemLink disabled href="#salkteam" onClick={() => props.executeScroll(SALK_TEAM)} selected={hash === `#${SALK_TEAM}`}>
               <ListItemText primary="Salk Institute Team" />
             </ListItemLink>
 
-            <ListItemLink href="#acmeteam" onClick={() => props.executeScroll(ACME_TEAM)} selected={hash === `#${ACME_TEAM}`}>
+            <ListItemLink disabled href="#acmeteam" onClick={() => props.executeScroll(ACME_TEAM)} selected={hash === `#${ACME_TEAM}`}>
               <ListItemText primary="Acme Team" />
             </ListItemLink>
           </List>
@@ -237,18 +237,18 @@ const Sidebar = (props) => {
         component="nav"
         disablePadding
       >
-        <ListItemLink href="#community" onClick={() => props.executeScroll(COMMUNITY_HASH)} selected={hash ===  `#${COMMUNITY_HASH}`}>
+        <ListItemLink disabled href="#community" onClick={() => props.executeScroll(COMMUNITY_HASH)} selected={hash ===  `#${COMMUNITY_HASH}`}>
           <ListItemIcon>
             <img src={COMMUNITY} alt="Community" />
           </ListItemIcon>
-          <ListItemText primary={`Community ${COMING_SOON}`}/>
+          <ListItemText primary={`Community`}/>
         </ListItemLink>
-        <ListItemLink href="#simple-list">
+        {/* <ListItemLink disabled href="#simple-list">
           <ListItemIcon>
             <img src={HELP} alt="help" />
           </ListItemIcon>
-          <ListItemText primary={`Help Center ${COMING_SOON}`} />
-        </ListItemLink>
+          <ListItemText primary={`Help Center`} />
+        </ListItemLink> */}
       </List>
 
       <Box className={classes.footer}>

--- a/applications/portal/frontend/src/utilities/constants.ts
+++ b/applications/portal/frontend/src/utilities/constants.ts
@@ -75,3 +75,4 @@ export enum Details {
 export const POPULATION_V1 = "V1"
 export const POPULATION_V2A = "V2a"
 export const alphanumericCollator = new Intl.Collator(undefined, {numeric: true, sensitivity: 'base'});
+export const COMING_SOON = "(coming soon)"

--- a/local-dev.sh
+++ b/local-dev.sh
@@ -1,0 +1,3 @@
+rm /opt/cloudharness/resources/auth/api_user_password
+kubectl -n salk get secrets accounts -o yaml|grep api_user_password|cut -d " " -f 4|base64 -d > /opt/cloudharness/resources/auth/api_user_password
+cp deployment/helm/values.yaml /opt/cloudharness/resources/allvalues.yaml


### PR DESCRIPTION
Closes #233

Implemented solution: 
- Adds coming soon message
- Makes teams tab start collapsed 

How to test this PR: 
- Open the home page and verify if the coming soon shows up in the proper tabs + verify if the teams tab starts collapsed

![image](https://user-images.githubusercontent.com/19196034/200928240-4fc9847a-6a35-43ed-9199-a0f6a63bcd2b.png)


### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
