### PR TITLE
chore: Upgrade itk version

### DIFF
--- a/applications/portal/cordmap/setup.cfg
+++ b/applications/portal/cordmap/setup.cfg
@@ -29,7 +29,7 @@ setup_requires =
 	setuptools_scm
 install_requires =
 	fire
-	itk==5.2.1.post1
+	itk==5.3.0
 	itk-elastix==0.13.0
 	napari[all]
 	napari-plugin-engine>=0.1.4


### PR DESCRIPTION
Tries to fix the [build problem](https://g.codefresh.io/build/64943cbf2f77f0a79897df7a?step=portal&tab=output&logs=terminal):
```
#12 19.28 Collecting itk-io==5.2.1.post1 (from itk==5.2.1.post1->cordmap==0.0.2rc2)                                                                              
#12 19.28   Downloading itk_io-5.2.1.post1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (15.0 MB)                                                    
#12 19.88      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸       12.6/15.0 MB 17.9 MB/s eta 0:00:01                                                                       
#12 19.89 ERROR: THESE PACKAGES DO NOT MATCH THE HASHES FROM THE REQUIREMENTS FILE. If you have updated the package versions, please update the hashes. Otherwise
, examine the package contents carefully; someone may have tampered with them.                                                                                   
#12 19.89     itk-io==5.2.1.post1 from https://files.pythonhosted.org/packages/a4/9e/1358ffb559515b24ebe3725c9e8fb6c049362e28891c49c2f430a16b9c32/itk_io-5.2.1.po
st1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (from itk==5.2.1.post1->cordmap==0.0.2rc2):                                                         
#12 19.89         Expected sha256 29e7760cfcea17d2cdef2af4c7d47e8ddb9aa107ba967d11478513d033cff8ee                                                               
#12 19.89              Got        eb8224f0eabb86f954c269b5b9069c1d79b8afb1883a73ccea6262d89f83b0d4                                                               
#12 19.89    
```

by upgrading itk from 5.2.1.post1 to 5.3.0