### PR TITLE
Docs update with generate canal, grid, lamina, annotation images script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ skaffold.yaml
 applications/workspaces/backend/static
 .overrides
 **/*.sqlite3
+applications/portal/frontend/src/assets/atlas/salk_cord_10um/*
+applications/portal/backend/persistent/*

--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ pip install -r requirements.txt
 ```
 
 
-Generate SALK Cord images 
-```
-./generate_images.sh
-```
 
 ## Deploy to a K8s cluster
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ cd cloud-harness
 pip install -r requirements.txt
 ```
 
+
+Generate SALK Cord images 
+```
+./generate_images.sh
+```
+
 ## Deploy to a K8s cluster
 
 Make sure that you are using the correct K8s context (check `kubectl config get-contexts`)

--- a/applications/portal/README.md
+++ b/applications/portal/README.md
@@ -35,6 +35,15 @@ sudo ln -s "$NVM_DIR/versions/node/$(nvm version)/bin/npm" "/usr/local/bin/npm"
 The local webpack dev server uses [keycloak_dev.json](src/assets/keycloak_dev.json) for connecting to the keycloak accounts system.
 Please check this file and change the domain according to your setup.
 
+
+### Generate SALK Cord images
+
+To generate SALK Cord images, once all the requirements for backend is installed, activate the virtual environment. And run the following command to generate the Salk Cord images .
+```
+./generate_images.sh
+```
+
+
 ### Self Signed Certificates
 
 When running on a local minikube please make sure you import the generated cacert certificates. The certificate file is most likely to be found here ./deployment/helm/resources/certs/cacert.crt

--- a/generate_images.sh
+++ b/generate_images.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-cd applications/portal/backend/
+# set the values for the variables below
+cd applications/portal/frontend
+BUILDDIR=$(pwd)
+cd ../backend
+APP_DIR=$(pwd)
 
 # Run Django management commands
 python3 manage.py generate_canal_images salk_cord_10um
@@ -9,4 +13,4 @@ python3 manage.py generate_lamina_images salk_cord_10um
 python3 manage.py generate_annotation_images salk_cord_10um
 
 # Copy files from the backend stage
-cp -r ${APP_DIR}/persistent/ ${BUILDDIR}/src/assets/atlas/salk_cord_10um/
+cp -r ${APP_DIR}/persistent/* ${BUILDDIR}/src/assets/atlas/salk_cord_10um/

--- a/generate_images.sh
+++ b/generate_images.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+cd applications/portal/backend/
+
+# Run Django management commands
+python3 manage.py generate_canal_images salk_cord_10um
+python3 manage.py generate_grid_images salk_cord_10um
+python3 manage.py generate_lamina_images salk_cord_10um
+python3 manage.py generate_annotation_images salk_cord_10um
+
+# Copy files from the backend stage
+cp -r ${APP_DIR}/persistent/ ${BUILDDIR}/src/assets/atlas/salk_cord_10um/


### PR DESCRIPTION
Closes #

Implemented solution: 
Added a script to generate canal, grid, lamina, annotation images and then move the files from backend to the frontend assets. 

How to test this PR: 
This is a helpful addition to the README.md which explicitly describes how to generate the images with one script i.e. `generate_images.sh`.

### Sanity checks:
- [ ] The pull request is explicitly linked to the relevant issue(s)
- [ ] The issue is well described: clearly states the problem and the general proposed solution(s)
- [ ] From the issue and the current PR it is explicitly stated how to test the current change
- [ ] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [ ] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [ ] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [x] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [x] The documentation has been updated to match the current changes
- [ ] The changes included in this PR are out of the current documentation scope

### Nice to have (if relevant):
- [ ] Screenshots of the changes
- [ ] Explanatory video/animated gif
