### PR TITLE
Feature/294

### DIFF
--- a/applications/portal/backend/api/helpers/population_cells.py
+++ b/applications/portal/backend/api/helpers/population_cells.py
@@ -22,3 +22,6 @@ def associate_population_cells_file(population, storage_path, csv_suffix):
             population.cells.save(new_file_name, File(file), save=True)
         population.status = PopulationStatus.FINISHED
         population.save()
+    else:
+        population.status = PopulationStatus.ERROR
+        population.save()

--- a/applications/portal/backend/api/management/commands/register_fiducial_experiment.py
+++ b/applications/portal/backend/api/management/commands/register_fiducial_experiment.py
@@ -3,11 +3,6 @@ from django.core.management.base import BaseCommand
 from api.management.utilities import create_populations_and_register_experiment
 from api.services.cordmap_service import is_a_population_single_file, get_populations, \
     SINGLE_FILE_POPULATION_ID_COLUMN
-from django.core.management.base import BaseCommand
-
-from api.management.utilities import create_populations_and_register_experiment
-from api.services.cordmap_service import is_a_population_single_file, get_populations, \
-    SINGLE_FILE_POPULATION_ID_COLUMN
 
 
 class Command(BaseCommand):
@@ -22,4 +17,4 @@ class Command(BaseCommand):
         filepath = options["filepath"]
 
         population_names = get_populations(filepath, is_a_population_single_file, SINGLE_FILE_POPULATION_ID_COLUMN)
-        create_populations_and_register_experiment(filepath, experiment_id, population_names)
+        create_populations_and_register_experiment(filepath, experiment_id, population_names, True)

--- a/applications/portal/backend/api/management/commands/register_non_fiducial_experiment.py
+++ b/applications/portal/backend/api/management/commands/register_non_fiducial_experiment.py
@@ -21,4 +21,4 @@ class Command(BaseCommand):
 
         population_names = get_populations(key_filepath, is_a_population_multiple_files,
                                            MULTIPLE_FILE_POPULATION_NAME_COLUMN)
-        create_populations_and_register_experiment(data_filepath, experiment_id, population_names)
+        create_populations_and_register_experiment(data_filepath, experiment_id, population_names, False)

--- a/applications/portal/backend/api/management/utilities.py
+++ b/applications/portal/backend/api/management/utilities.py
@@ -9,14 +9,14 @@ def get_valid_atlases():
     return valid_atlas_ids
 
 
-def create_populations_and_register_experiment(data_filepath, experiment_id, population_names):
+def create_populations_and_register_experiment(data_filepath, experiment_id, population_names, is_fiducial=False):
     populations = []
     with transaction.atomic():
         for name in population_names:
             populations.append(Population.objects.create(
                 experiment_id=experiment_id,
                 name=name,
-                is_fiducial=False,
+                is_fiducial=is_fiducial,
                 status=PopulationStatus.PENDING
             ))
     experiment = Experiment.objects.get(pk=experiment_id)

--- a/applications/portal/backend/api/services/experiment_service.py
+++ b/applications/portal/backend/api/services/experiment_service.py
@@ -1,3 +1,5 @@
+import logging
+
 from api.helpers.experiment_registration.experiment_registration_strategy_factory import get_registration_strategy
 from api.helpers.population_cells import associate_population_cells_file
 from api.models import Experiment, Tag, Population, PopulationStatus
@@ -65,7 +67,8 @@ def register_experiment(populations, filepath, storage_path):
         for population in populations:
             associate_population_cells_file(population, storage_path, csv_suffix)
 
-    except Exception:
+    except Exception as e:
+        logging.error(e)
         for population in populations:
             population.status = PopulationStatus.ERROR
             population.save()

--- a/applications/portal/cordmap/cordmap/entry_points/register_3D_fiducial.py
+++ b/applications/portal/cordmap/cordmap/entry_points/register_3D_fiducial.py
@@ -68,6 +68,7 @@ def register_3D_fiducial(
         )
 
     if save:
+        labeled_cells = labeled_cells.rename(columns={"x": "y", "y": "x"})  # swap x and y
         save_output(
             output_directory,
             labeled_cells,

--- a/applications/portal/frontend/src/components/viewers/twoD/TwoDViewer.tsx
+++ b/applications/portal/frontend/src/components/viewers/twoD/TwoDViewer.tsx
@@ -181,7 +181,8 @@ const getDefaultOverlays = () => {
 }
 
 const TwoDViewer = (props: {
-    subdivisions: string[], activePopulations: Population[],
+    subdivisions: string[],
+    activePopulations: Population[],
     selectedAtlas: AtlasChoice,
     invalidCachePopulations: Set<string>
 }) => {

--- a/applications/portal/frontend/src/pages/ExperimentsPage.tsx
+++ b/applications/portal/frontend/src/pages/ExperimentsPage.tsx
@@ -202,13 +202,13 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({residential
             const cells = await Promise.all(fetchedExperiment.populations.map(async (p) => {
                 if (p.status !== POPULATION_FINISHED_STATE) return [];
                 const existingPopulation = experiment.populations.find((e: ExperimentPopulationsInner) => e.id === p.id)
-                if (existingPopulation !== undefined && typeof existingPopulation.cells !== "string" && existingPopulation.cells.length > 0) return existingPopulation.cells
+                if (existingPopulation !== undefined && typeof existingPopulation.cells !== "string") return existingPopulation.cells
                 return getCells(api, p);
             }));
             let shouldUpdateExperiment = false;
             fetchedExperiment.populations.forEach((p, i) => {
                 const existingPopulation = experiment.populations.find((e: ExperimentPopulationsInner) => e.id === p.id)
-                if (existingPopulation === undefined || typeof existingPopulation.cells === "string" || existingPopulation.cells.length === 0) {
+                if (existingPopulation === undefined || typeof existingPopulation.cells === "string") {
                     // previous population cells !== new population cells --> update the experiment data
                     shouldUpdateExperiment = true;
                 }

--- a/applications/portal/frontend/src/pages/ExperimentsPage.tsx
+++ b/applications/portal/frontend/src/pages/ExperimentsPage.tsx
@@ -200,15 +200,19 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({residential
             const response = await api.retrieveExperiment(params.id)
             const fetchedExperiment = response.data;
             const cells = await Promise.all(fetchedExperiment.populations.map(async (p) => {
-                if (p.status !== POPULATION_FINISHED_STATE) return [];
+                if (p.status !== POPULATION_FINISHED_STATE) return null;
                 const existingPopulation = experiment.populations.find((e: ExperimentPopulationsInner) => e.id === p.id)
-                if (existingPopulation !== undefined && typeof existingPopulation.cells !== "string") return existingPopulation.cells
+                if (existingPopulation !== undefined && typeof existingPopulation.cells !== "string"
+                    && existingPopulation.cells !== null){
+                    return existingPopulation.cells
+                }
                 return getCells(api, p);
             }));
             let shouldUpdateExperiment = false;
             fetchedExperiment.populations.forEach((p, i) => {
                 const existingPopulation = experiment.populations.find((e: ExperimentPopulationsInner) => e.id === p.id)
-                if (existingPopulation === undefined || typeof existingPopulation.cells === "string") {
+                if (existingPopulation === undefined || typeof existingPopulation.cells === "string" ||
+                    (existingPopulation.cells === null && cells[i] !== null)){
                     // previous population cells !== new population cells --> update the experiment data
                     shouldUpdateExperiment = true;
                 }
@@ -243,7 +247,9 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({residential
             const response = await api.retrieveExperiment(params.id)
             const data = response.data;
             const cells = await Promise.all(data.populations.map(async (p) => {
-                if (p.status !== POPULATION_FINISHED_STATE) return [];
+                if (p.status !== POPULATION_FINISHED_STATE){
+                    return null;
+                }
                 return getCells(api, p);
             }));
             data.populations.forEach((p, i) => {

--- a/applications/portal/frontend/src/pages/HomePage.tsx
+++ b/applications/portal/frontend/src/pages/HomePage.tsx
@@ -11,7 +11,6 @@ import {
   ACME_TEAM,
   COMMUNITY_HASH,
   SHARED_HASH,
-  PULL_TIME_MS
 } from "../utilities/constants";
 import { CloneExperimentDialog } from "../components/home/CloneExperimentDialog";
 import { ExplorationSpinalCordDialog } from "../components/home/ExplorationSpinalCordDialog";


### PR DESCRIPTION
Closes #294 

Implemented solution: 
- Sets default population cells, while registration is still running, to null instead of empty array and updates check to refresh the experiment data to use that.

Misc:
- Improves population state handling by setting populations to which cordmap doesn't return a cells file to error state.
- Fixes fiducial experiment registration
- Adds back custom cordmap change to switch columns

How to test this PR: 
- Open an experiment where one of the populations is in a non final state (f.e. error state) 
- Activate one of the populations ready. 
- Activate the show centroids option in the 2D Viewer.
- Wait at most 30 seconds, so that the frontend pulls data from the server
- Confirm that the twoDViewer and threeDViewer do not reset.

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
