### PR TITLE
Feature/286

### DIFF
--- a/applications/portal/backend/api/helpers/download_populations.py
+++ b/applications/portal/backend/api/helpers/download_populations.py
@@ -1,0 +1,48 @@
+import csv
+import io
+import os
+import tempfile
+import zipfile
+
+from django.db.models import Q
+from django.http import HttpResponse
+
+from api.models import Population
+
+
+def get_populations_zip(active_populations, experiment):
+    filename_prefix = f'{experiment.name}' if experiment else 'population'
+    filename_suffix = 's' if len(active_populations) > 1 else ''
+
+    temp_file = tempfile.TemporaryFile()
+    with zipfile.ZipFile(temp_file, 'w') as zip_file:
+        for population in Population.objects.filter(Q(experiment=experiment) | Q(experiment=None), id__in=active_populations):
+            if population.cells:
+                modified_csv_content = modify_csv_headers(population.cells.path)
+                zip_file.writestr(os.path.basename(population.cells.path), modified_csv_content)
+                filename_prefix += f"_{population.name}"
+
+    temp_file.seek(0)  # Reset file pointer
+    return temp_file, f"{filename_prefix}_population{filename_suffix}.zip"
+
+
+
+def modify_csv_headers(csv_file_path):
+    with open(csv_file_path, 'r') as csvfile:
+        reader = csv.reader(csvfile)
+        modified_data = io.StringIO()
+        writer = csv.writer(modified_data)
+
+        # Swap 'x' and 'y' in headers
+        headers = next(reader)
+        x_index = headers.index('x')
+        y_index = headers.index('y')
+        headers[x_index], headers[y_index] = headers[y_index], headers[x_index]
+        writer.writerow(headers)
+
+        # Write the rest of the rows as they are
+        for row in reader:
+            writer.writerow(row)
+
+        modified_data.seek(0)
+        return modified_data.getvalue()

--- a/applications/portal/backend/api/helpers/population_cells.py
+++ b/applications/portal/backend/api/helpers/population_cells.py
@@ -22,3 +22,6 @@ def associate_population_cells_file(population, storage_path, csv_suffix):
             population.cells.save(new_file_name, File(file), save=True)
         population.status = PopulationStatus.FINISHED
         population.save()
+    else:
+        population.status = PopulationStatus.ERROR
+        population.save()

--- a/applications/portal/backend/api/helpers/population_cells.py
+++ b/applications/portal/backend/api/helpers/population_cells.py
@@ -15,7 +15,7 @@ def associate_population_cells_file(population, storage_path, csv_suffix):
         new_file_name = f"{csv_suffix}_{str(uuid.uuid4())[:8]}.csv"
         new_file_path = move_file(
             original_file_path,
-            os.path.join(population.storage_path, str(population.id)),
+            population.storage_path,
             new_file_name
         )
         with open(new_file_path, 'rb') as file:

--- a/applications/portal/backend/api/management/commands/register_fiducial_experiment.py
+++ b/applications/portal/backend/api/management/commands/register_fiducial_experiment.py
@@ -3,11 +3,6 @@ from django.core.management.base import BaseCommand
 from api.management.utilities import create_populations_and_register_experiment
 from api.services.cordmap_service import is_a_population_single_file, get_populations, \
     SINGLE_FILE_POPULATION_ID_COLUMN
-from django.core.management.base import BaseCommand
-
-from api.management.utilities import create_populations_and_register_experiment
-from api.services.cordmap_service import is_a_population_single_file, get_populations, \
-    SINGLE_FILE_POPULATION_ID_COLUMN
 
 
 class Command(BaseCommand):
@@ -22,4 +17,4 @@ class Command(BaseCommand):
         filepath = options["filepath"]
 
         population_names = get_populations(filepath, is_a_population_single_file, SINGLE_FILE_POPULATION_ID_COLUMN)
-        create_populations_and_register_experiment(filepath, experiment_id, population_names)
+        create_populations_and_register_experiment(filepath, experiment_id, population_names, True)

--- a/applications/portal/backend/api/management/commands/register_non_fiducial_experiment.py
+++ b/applications/portal/backend/api/management/commands/register_non_fiducial_experiment.py
@@ -21,4 +21,4 @@ class Command(BaseCommand):
 
         population_names = get_populations(key_filepath, is_a_population_multiple_files,
                                            MULTIPLE_FILE_POPULATION_NAME_COLUMN)
-        create_populations_and_register_experiment(data_filepath, experiment_id, population_names)
+        create_populations_and_register_experiment(data_filepath, experiment_id, population_names, False)

--- a/applications/portal/backend/api/management/utilities.py
+++ b/applications/portal/backend/api/management/utilities.py
@@ -9,14 +9,14 @@ def get_valid_atlases():
     return valid_atlas_ids
 
 
-def create_populations_and_register_experiment(data_filepath, experiment_id, population_names):
+def create_populations_and_register_experiment(data_filepath, experiment_id, population_names, is_fiducial=False):
     populations = []
     with transaction.atomic():
         for name in population_names:
             populations.append(Population.objects.create(
                 experiment_id=experiment_id,
                 name=name,
-                is_fiducial=False,
+                is_fiducial=is_fiducial,
                 status=PopulationStatus.PENDING
             ))
     experiment = Experiment.objects.get(pk=experiment_id)

--- a/applications/portal/backend/api/services/experiment_service.py
+++ b/applications/portal/backend/api/services/experiment_service.py
@@ -1,3 +1,5 @@
+import logging
+
 from api.helpers.experiment_registration.experiment_registration_strategy_factory import get_registration_strategy
 from api.helpers.population_cells import associate_population_cells_file
 from api.models import Experiment, Tag, Population, PopulationStatus
@@ -65,7 +67,8 @@ def register_experiment(populations, filepath, storage_path):
         for population in populations:
             associate_population_cells_file(population, storage_path, csv_suffix)
 
-    except Exception:
+    except Exception as e:
+        logging.error(e)
         for population in populations:
             population.status = PopulationStatus.ERROR
             population.save()

--- a/applications/portal/cordmap/cordmap/entry_points/register_3D_fiducial.py
+++ b/applications/portal/cordmap/cordmap/entry_points/register_3D_fiducial.py
@@ -68,6 +68,7 @@ def register_3D_fiducial(
         )
 
     if save:
+        labeled_cells = labeled_cells.rename(columns={"x": "y", "y": "x"})  # swap x and y
         save_output(
             output_directory,
             labeled_cells,

--- a/applications/portal/frontend/src/components/viewers/twoD/TwoDViewer.tsx
+++ b/applications/portal/frontend/src/components/viewers/twoD/TwoDViewer.tsx
@@ -181,7 +181,8 @@ const getDefaultOverlays = () => {
 }
 
 const TwoDViewer = (props: {
-    subdivisions: string[], activePopulations: Population[],
+    subdivisions: string[],
+    activePopulations: Population[],
     selectedAtlas: AtlasChoice,
     invalidCachePopulations: Set<string>
 }) => {

--- a/applications/portal/frontend/src/pages/ExperimentsPage.tsx
+++ b/applications/portal/frontend/src/pages/ExperimentsPage.tsx
@@ -202,13 +202,13 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({residential
             const cells = await Promise.all(fetchedExperiment.populations.map(async (p) => {
                 if (p.status !== POPULATION_FINISHED_STATE) return [];
                 const existingPopulation = experiment.populations.find((e: ExperimentPopulationsInner) => e.id === p.id)
-                if (existingPopulation !== undefined && typeof existingPopulation.cells !== "string" && existingPopulation.cells.length > 0) return existingPopulation.cells
+                if (existingPopulation !== undefined && typeof existingPopulation.cells !== "string") return existingPopulation.cells
                 return getCells(api, p);
             }));
             let shouldUpdateExperiment = false;
             fetchedExperiment.populations.forEach((p, i) => {
                 const existingPopulation = experiment.populations.find((e: ExperimentPopulationsInner) => e.id === p.id)
-                if (existingPopulation === undefined || typeof existingPopulation.cells === "string" || existingPopulation.cells.length === 0) {
+                if (existingPopulation === undefined || typeof existingPopulation.cells === "string") {
                     // previous population cells !== new population cells --> update the experiment data
                     shouldUpdateExperiment = true;
                 }

--- a/applications/portal/frontend/src/pages/ExperimentsPage.tsx
+++ b/applications/portal/frontend/src/pages/ExperimentsPage.tsx
@@ -200,15 +200,19 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({residential
             const response = await api.retrieveExperiment(params.id)
             const fetchedExperiment = response.data;
             const cells = await Promise.all(fetchedExperiment.populations.map(async (p) => {
-                if (p.status !== POPULATION_FINISHED_STATE) return [];
+                if (p.status !== POPULATION_FINISHED_STATE) return null;
                 const existingPopulation = experiment.populations.find((e: ExperimentPopulationsInner) => e.id === p.id)
-                if (existingPopulation !== undefined && typeof existingPopulation.cells !== "string") return existingPopulation.cells
+                if (existingPopulation !== undefined && typeof existingPopulation.cells !== "string"
+                    && existingPopulation.cells !== null){
+                    return existingPopulation.cells
+                }
                 return getCells(api, p);
             }));
             let shouldUpdateExperiment = false;
             fetchedExperiment.populations.forEach((p, i) => {
                 const existingPopulation = experiment.populations.find((e: ExperimentPopulationsInner) => e.id === p.id)
-                if (existingPopulation === undefined || typeof existingPopulation.cells === "string") {
+                if (existingPopulation === undefined || typeof existingPopulation.cells === "string" ||
+                    (existingPopulation.cells === null && cells[i] !== null)){
                     // previous population cells !== new population cells --> update the experiment data
                     shouldUpdateExperiment = true;
                 }
@@ -243,7 +247,9 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({residential
             const response = await api.retrieveExperiment(params.id)
             const data = response.data;
             const cells = await Promise.all(data.populations.map(async (p) => {
-                if (p.status !== POPULATION_FINISHED_STATE) return [];
+                if (p.status !== POPULATION_FINISHED_STATE){
+                    return null;
+                }
                 return getCells(api, p);
             }));
             data.populations.forEach((p, i) => {

--- a/applications/portal/frontend/src/pages/HomePage.tsx
+++ b/applications/portal/frontend/src/pages/HomePage.tsx
@@ -11,7 +11,6 @@ import {
   ACME_TEAM,
   COMMUNITY_HASH,
   SHARED_HASH,
-  PULL_TIME_MS
 } from "../utilities/constants";
 import { CloneExperimentDialog } from "../components/home/CloneExperimentDialog";
 import { ExplorationSpinalCordDialog } from "../components/home/ExplorationSpinalCordDialog";


### PR DESCRIPTION
Closes #286 

Implemented solution: 
- In the backend, when we create the zip to download the populations, we switch the the columns of the in-memory csv files.
I opted to follow this strategy, opposed to change the way we save the cells file after the registration because that would involve changes in the threeDViewer and twoDViewer and the update of all the existent populations to follow the new format.

Misc:
- Also fixes a typo in the save location of the population cells. This won't need a migration because the only data affected by this was test data I used yesterday

How to test this PR: 
- Click to download a population. You should see the 'x' and 'y' columns swapped.

(before)
![image](https://github.com/MetaCell/salk-interactive-atlas/assets/19196034/5816f344-cc4e-4002-a711-3d7617d93dc5)

(after)
![image](https://github.com/MetaCell/salk-interactive-atlas/assets/19196034/4d9f32ea-aa20-44c8-9f50-061b4b1e158b)


### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope