### PR TITLE
Feature/335 - download active populations text

### DIFF
--- a/applications/portal/frontend/src/components/sidebar/PopulationsAccordion.jsx
+++ b/applications/portal/frontend/src/components/sidebar/PopulationsAccordion.jsx
@@ -179,9 +179,9 @@ const PopulationsAccordion = ({
                         disableRipple
                         onClick={() => downloadPopulationsData()}
                         disabled={!activePopulations.length}
-                        style={{ fontWeight: 400 }}
+                        style={{ fontWeight: 400, padding: '1.5rem 1rem 1rem 1rem' }}
                     >
-                        Download actives
+                        Download active populations
                         <img src={DOWNLOAD_ICON} alt="" />
                     </Button>
                 </Tooltip>


### PR DESCRIPTION
Closes #335 

Implemented solution: ... 
After the change, it looks as follows. 

![image](https://github.com/MetaCell/salk-interactive-atlas/assets/59233227/5bfb8e46-f0a3-4265-8c5e-f5c91d4bec4a)


The CSS change to expand the width was necessary, since the text were long and looked bad. 
![image](https://github.com/MetaCell/salk-interactive-atlas/assets/59233227/cfd4bf31-843f-4238-b27b-043ed5a3b5e6)


