### PR TITLE
Feature/343 - Copy Link from Card and Disable unimplemented features 

### DIFF
--- a/applications/portal/frontend/src/components/home/ExperimentCard.jsx
+++ b/applications/portal/frontend/src/components/home/ExperimentCard.jsx
@@ -309,6 +309,11 @@ const ExperimentCard = ({
         setOpenDeleteDialog(!openDeleteDialog);
     };
 
+    const handleCopyLink = () => {
+        closeFilter();
+        navigator.clipboard.writeText(`${window.location.origin}/experiments/${experiment.id}`);
+    };
+
     React.useEffect(() => {
         const fetchTagOptions = async () => {
             const res = await api.listTags()
@@ -342,10 +347,11 @@ const ExperimentCard = ({
                         <ListItemText primary="Edit info and tags" />
                     </ListItem>
                     <Divider />
-                    <ListItem button>
+                    <ListItem button onClick={handleCopyLink}>
                         <ListItemText primary="Copy link" />
                     </ListItem>
-                    <ListItem>
+                    {/* Disabled Feature: for future */}
+                    {/* <ListItem>
                         <ListItemText primary="Share" secondary={<ArrowRightIcon />} />
                         <List component="nav" aria-label="secondary mailbox folders">
                             <ListItem button onClick={handleShareDialogToggle}>
@@ -355,7 +361,7 @@ const ExperimentCard = ({
                                 <ListItemText primary="Share multiple experiments" />
                             </ListItem>
                         </List>
-                    </ListItem>
+                    </ListItem> */}
                     <Divider />
                     <ListItem button>
                         {type === EXPERIMENTS_HASH ? <ListItemText primary="Delete" onClick={() => handleDeleteDialog()} /> :


### PR DESCRIPTION
Closes #343

Implemented solution: 

+ implement copy link 
+ disable the unimplemented feature - share experiments from the Menu list 


![image](https://github.com/MetaCell/salk-interactive-atlas/assets/59233227/a057547a-9d5f-4ab5-8a2e-b9f9d8256d0b)
