### PR TITLE
Feature/350

### DIFF
--- a/applications/portal/frontend/src/components/sidebar/PopulationsAccordion.jsx
+++ b/applications/portal/frontend/src/components/sidebar/PopulationsAccordion.jsx
@@ -53,15 +53,16 @@ const PopulationsAccordion = ({
         }
     }
 
-    const handlePopulationsWithChildrenColorChange = (population, color, opacity) => {
-        // If the population has children, call handlePopulationColorChange for each child
+    const handlePopulationsWithChildrenColorChange = async (population, color, opacity, setPopulations) => {
         const children = population.children;
         if (children) {
-            Object.keys(children).forEach(childId => {
-                handlePopulationColorChange(childId, color, opacity);
+            const updates = Object.keys(children).map(childId => {
+                return { id: childId, color, opacity };
             });
+
+            await handlePopulationColorChange(updates, setPopulations);
         }
-    }
+    };
     const activePopulations = Object.values(populations)
         .flatMap(population => population.children ? Object.values(population.children) : [])
         .filter(child => child.selected)
@@ -167,7 +168,13 @@ const PopulationsAccordion = ({
                                                         isParent={false}
                                                         population={populations[pId]?.children[nestedPId]}
                                                         handlePopulationSwitch={handleChildPopulationSwitch}
-                                                        handlePopulationColorChange={handlePopulationColorChange}
+                                                        handlePopulationColorChange={(id, color, opacity) =>
+                                                            handlePopulationColorChange([{
+                                                                id: id,
+                                                                color: color,
+                                                                opacity: opacity
+                                                            }])}
+
                                                         hasEditPermission={hasEditPermission}
                                                     />
                                                 </Accordion>

--- a/applications/portal/frontend/src/pages/ExperimentsPage.tsx
+++ b/applications/portal/frontend/src/pages/ExperimentsPage.tsx
@@ -220,17 +220,29 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({ residentia
     }
 
 
-    const handlePopulationColorChange = async (id: string, color: string, opacity: string) => {
-        if (id) {
+    const handlePopulationColorChange = async (updates: Array<{ id: string, color: string, opacity: number }>) => {
+        const updatePromises = updates.map(update =>
             // @ts-ignore
-            await api.partialUpdatePopulation(id, { color, opacity })
+            api.partialUpdatePopulation(update.id, { color: update.color, opacity: update.opacity })
+        );
+
+        try {
+            await Promise.all(updatePromises);
+
+            setPopulations((prevPopulations) => {
+                const nextPopulations = { ...prevPopulations };
+                updates.forEach(({ id, color, opacity }) => {
+                    if (nextPopulations[id]) {
+                        // @ts-ignore
+                        nextPopulations[id] = { ...nextPopulations[id], color, opacity };
+                    }
+                });
+                return nextPopulations;
+            });
+        } catch (error) {
+            setErrorMessage("Couldn't update population color")
         }
-        // @ts-ignore
-        const nextPopulations = { ...populations };
-        // @ts-ignore
-        nextPopulations[id] = { ...nextPopulations[id], color, opacity }
-        setPopulations(nextPopulations)
-    }
+    };
 
     const handleSubPopulationDotSizeChange = (newPopulationDotSizes: DotSizeType) => {
         setPopulationDotSizes(newPopulationDotSizes)

--- a/applications/portal/frontend/src/pages/ExperimentsPage.tsx
+++ b/applications/portal/frontend/src/pages/ExperimentsPage.tsx
@@ -239,6 +239,8 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({ residentia
                 });
                 return nextPopulations;
             });
+            setErrorMessage("Just testing")
+
         } catch (error) {
             setErrorMessage("Couldn't update population color")
         }
@@ -409,7 +411,7 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({ residentia
             </Box>
             <SnackMessage
                 message={errorMessage}
-                setMesssage={setErrorMessage}
+                setMessage={setErrorMessage}
             />
         </Box>
     ) : <Loader />


### PR DESCRIPTION
Closes #350 

Implemented solution: 
- Awaits for all the children color changes before updating populations
- Fixes typo

How to test this PR: 
- Change the color of a 'parent' population with many children

### Sanity checks:
- [x] The pull request is explicitly linked to the relevant issue(s)
- [x] The issue is well described: clearly states the problem and the general proposed solution(s)
- [x] From the issue and the current PR it is explicitly stated how to test the current change
- [x] The labels in the issue set the scope and the type of issue (bug, feature, etc.)
- [x] All the automated test checks are passing
- [ ] All the linked issues are included in one milestone
- [x] All the linked issues are assigned

### Breaking changes (select one):
- [x] The present changes do not change the preexisting api in any way
- [ ] This PR and the issue are tagged as a `breaking-change`

### Possible deployment updates issues (select one):
- [x] There is no reason why deployments may break after the current update
- [ ] This PR and the issue are tagged as `alert:deployment`

### Test coverage (select one):
- [ ] Tests for the relevant cases are included in this pr
- [x] The changes included in this pr are out of the current test coverage scope

### Documentation (select one):
- [ ] The documentation has been updated to match the current changes
- [x] The changes included in this PR are out of the current documentation scope
