### PR TITLE
Feature/352: Remove/comment - my account modal buttons and edit sections

### DIFF
--- a/applications/portal/frontend/src/components/common/ExperimentDialogs/OwnerInfo.jsx
+++ b/applications/portal/frontend/src/components/common/ExperimentDialogs/OwnerInfo.jsx
@@ -6,8 +6,6 @@ import {
   Avatar,
 } from "@material-ui/core";
 import { headerButtonBorderColor, sidebarTextColor } from "../../../theme";
-import USER from "../../../assets/images/icons/user.svg";
-
 const useStyles = makeStyles(() => ({
   ownerInfo: {
     '& .MuiTypography-root': {
@@ -33,7 +31,7 @@ export const OwnerInfo = (props) => {
 
   return (
     <Box display="flex" alignItems={"center"} className={classes.ownerInfo}>
-      <Avatar title={user?.username} src={user.avatarUrl ? user.avatarUrl : USER} />
+      <Avatar title={user?.username} src={user.avatarUrl ? user.avatarUrl : null} />
       <Typography>
         {`${user?.firstName} ${user?.lastName}`} <Typography component="span">(You)</Typography>
       </Typography>

--- a/applications/portal/frontend/src/components/header/Header.tsx
+++ b/applications/portal/frontend/src/components/header/Header.tsx
@@ -15,7 +15,6 @@ import { headerBorderColor, headerButtonBorderColor, headerBg } from "../../them
 // @ts-ignore
 import LOGO from "../../assets/images/logo.svg";
 // @ts-ignore
-import USER from "../../assets/images/icons/user.svg";
 import { UserAccountDialog } from "./UserAccountDialog";
 import { CreateUpdateExperimentDialog } from "./ExperimentDialog/CreateUpdateExperimentDialog";
 import { EXPERIMENTS_ROUTE, HEADER_TITLE, SNACKBAR_TIMEOUT } from "../../utilities/constants";
@@ -224,7 +223,7 @@ export const Header = ({
                             My account
                         </Button>
 
-                        <Avatar alt={user.username} title={user.username} src={user.avatarUrl ? user.avatarUrl : USER} />
+                        <Avatar alt={user.username} title={user.username} src={user.avatarUrl ? user.avatarUrl : null} />
                     </>
                 ) : (
                     <>

--- a/applications/portal/frontend/src/components/header/UserAccountDialog.tsx
+++ b/applications/portal/frontend/src/components/header/UserAccountDialog.tsx
@@ -10,7 +10,6 @@ import {
   FormControlLabel,
 } from "@material-ui/core";
 import { headerBorderColor, headerButtonBorderColor, headerBg, secondaryColor, switchActiveColor } from "../../theme";
-import USER from "../../assets/images/icons/user.svg";
 import Modal from "../common/BaseDialog";
 
 const useStyles = makeStyles(() => ({
@@ -96,7 +95,7 @@ export const UserAccountDialog = (props: any) => {
   return (
     <Modal open={Boolean(open)} handleClose={handleClose} title="My account">
       <Box display="flex" className={classes.myAccount}>
-        <Avatar alt="user" src={USER} />
+        <Avatar title={user?.username} src={user.avatarUrl ? user.avatarUrl : null} />
         <Box className="details">
           <Box className="detail-block">
             <Typography component="h4">Name</Typography>

--- a/applications/portal/frontend/src/components/header/UserAccountDialog.tsx
+++ b/applications/portal/frontend/src/components/header/UserAccountDialog.tsx
@@ -101,22 +101,22 @@ export const UserAccountDialog = (props: any) => {
           <Box className="detail-block">
             <Typography component="h4">Name</Typography>
             <Typography component={"p"}>{`${user?.firstName} ${user?.lastName}`}</Typography>
-            <Button disableRipple="true" variant="text">Edit</Button>
+            {/* <Button disableRipple="true" variant="text">Edit</Button> */}
           </Box>
 
           <Box className="detail-block">
             <Typography component="h4">Email</Typography>
             <Typography component={"p"}>{user?.email}</Typography>
-            <Button disableRipple="true" variant="text">Edit</Button>
+            {/* <Button disableRipple="true" variant="text">Edit</Button> */}
           </Box>
 
-          <Box className="detail-block">
+          {/* <Box className="detail-block">
             <Typography component="h4">Password</Typography>
             <Typography component={"p"}>●●●●●●●●●●●●●</Typography>
             <Button disableRipple="true" variant="text">Change password</Button>
-          </Box>
+          </Box> */}
 
-          <Divider />
+          {/* <Divider />
           <Box className="detail-block">
             <Typography component="h4">Notifications by email</Typography>
             {
@@ -125,13 +125,14 @@ export const UserAccountDialog = (props: any) => {
                   key={option}
                   control={<Switch />}
                   label={option}
+                  disabled
                 />
               ))
             }
           </Box>
           <Divider />
 
-          <Button variant="outlined">Delete my account</Button>
+          <Button variant="outlined" disabled>Delete my account</Button> */}
         </Box>
       </Box>
     </Modal>

--- a/applications/portal/frontend/src/components/home/ExperimentCard.jsx
+++ b/applications/portal/frontend/src/components/home/ExperimentCard.jsx
@@ -21,7 +21,6 @@ import {
     cardTextColor,
     secondaryColor
 } from "../../theme";
-import USER from "../../assets/images/icons/user.svg";
 import POPULAR from "../../assets/images/icons/popular.svg";
 import CLONE from "../../assets/images/icons/clone.svg";
 import PLACEHOLDER from "../../assets/images/placeholder.png";
@@ -416,7 +415,7 @@ const ExperimentCard = ({
                                 {experiment.owner.username}
                             </Typography>
                         } placement="top">
-                            <Avatar src={experiment.owner.avatar ? experiment.owner.avatar : USER} alt={experiment.owner.username} />
+                            <Avatar src={experiment.owner.avatar ? experiment.owner.avatar : null} alt={experiment.owner.username} />
                         </Tooltip>
                     </CardContent>
                 </CardActionArea>

--- a/applications/portal/frontend/src/pages/ExperimentsPage.tsx
+++ b/applications/portal/frontend/src/pages/ExperimentsPage.tsx
@@ -252,7 +252,6 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({ residentia
                 });
                 return nextPopulations;
             });
-            setErrorMessage("Just testing")
 
         } catch (error) {
             setErrorMessage("Couldn't update population color")


### PR DESCRIPTION
Closes #352 


Implemented solution: 
Instead of disabling the sections, the sections have been commented out (removed from the view)


How it looks after:
![image](https://github.com/MetaCell/salk-interactive-atlas/assets/59233227/1e5d0a32-25e6-40cf-93f0-1603d0aedcae)
