### PR TITLE
337-Cell size slider misplaced

### DIFF
--- a/applications/portal/frontend/src/components/common/ExperimentDialogs/NeuronDotSize.jsx
+++ b/applications/portal/frontend/src/components/common/ExperimentDialogs/NeuronDotSize.jsx
@@ -1,13 +1,18 @@
 import React, { useCallback } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Box, Typography, Slider, Divider, IconButton, Dialog, DialogTitle, DialogContent, Button } from '@material-ui/core';
-import { headerBorderColor } from "../../../theme";
+import { Box, Typography, Slider, Divider, IconButton, Button, Popover } from '@material-ui/core';
+import { headerBorderColor, switchActiveColor } from "../../../theme";
 import CLOSE from "../../../assets/images/icons/close.svg";
 import { EXPERIMENTAL_POPULATION_NAME, RESIDENTIAL_POPULATION_NAME } from "../../../utilities/constants";
 
 
 const useStyles = makeStyles((theme) => ({
-  dialogContent: {
+  titleBox:{
+    padding: '0.75rem', 
+    color: 'rgba(255, 255, 255, 0.80)',
+    borderBottom: `1px solid ${headerBorderColor}`,
+  },
+  popoverContent: {
     display: 'flex',
     flexDirection: 'column',
     padding: theme.spacing(2),
@@ -41,23 +46,25 @@ const useStyles = makeStyles((theme) => ({
     '& .row-container': {
       display: 'flex',
       alignItems: 'center',
-      marginBottom: theme.spacing(1),
+      '& .MuiTypography-body1': {
+        color: 'rgba(255, 255, 255, 0.80)'
+      }
     },
     '& .row-slider': {
       display: 'flex',
       alignItems: 'center',
       justifyContent: 'space-between',
-      marginBottom: theme.spacing(2),
     },
     '& .disable-text': {
       fontWeight: 400,
       fontSize: '0.75rem',
-      color: '#999999',
+      color: 'rgba(255, 255, 255, 0.40)',
     },
 
   },
   slider: {
     width: '80%',
+    color: switchActiveColor,
   },
   closeButton: {
     marginTop: theme.spacing(2),
@@ -67,32 +74,23 @@ const useStyles = makeStyles((theme) => ({
     width: '100%',
     maxWidth: '25rem',
     margin: '0rem',
-    '& .MuiDialogContent-root': {
-      padding: '0rem',
+    borderRadius: '0.25rem',
+    border: '1px solid #353739',
+    background: '#1E1E1E', 
+    boxShadow: '0px 4px 6px -2px rgba(0, 0, 0, 0.20), 0px 12px 40px -4px rgba(0, 0, 0, 0.30)',
+    '& .MuiIconButton-root': {
+      padding: 0
     },
     '& .MuiButton-label': {
       padding: 0,
-    },
-    '& .MuiButton-root': {
-      padding: '0.4rem',
-      minWidth: '40px',
-    },
-    '& .MuiDialogTitle-root': {
-      padding: '0.125rem 0.25rem 0.125rem 0.8rem',
-    },
-
-  },
-  dialogContainer: {
-    '& .MuiDialog-container': {
-      display: 'block',
-    },
-  },
+    }
+  }
 }));
 
 const NeuronDotSize = ({
-  open, onClose, populations, anchorElement,
+  id, open, onClose, populations, anchorElement,
   activePopulations, handleSubPopulationDotSizeChange,
-  dialogPopulationsSelected, populationDotSizes,
+  dialogPopulationsSelected, populationDotSizes
 }) => {
   const classes = useStyles();
   const [globalDotSize, setGlobalDotSize] = React.useState({
@@ -117,16 +115,6 @@ const NeuronDotSize = ({
       value: 100,
     },
   ];
-  const getPositionStyles = () => {
-    if (!anchorElement) {
-      return {};
-    }
-    return {
-      marginLeft: anchorElement?.left + anchorElement?.width + 60,
-      marginTop: anchorElement?.top,
-    };
-  };
-
 
 
   const populationSelected = dialogPopulationsSelected?.populations;
@@ -160,23 +148,35 @@ const NeuronDotSize = ({
   }, [handleSubPopulationDotSizeChange]);
 
   return (
-    <Dialog open={open} onClose={onClose}
+    <Popover
       classes={{
         paper: classes.popupContainer,
       }}
-      className={classes.dialogContainer}
-      fullWidth={true}
-      style={{ ...getPositionStyles() }}
+      id={id}
+      open={open}
+      anchorEl={anchorElement}
+      onClose={onClose}
+      anchorOrigin={{
+        vertical: 'center',
+        horizontal: 'right',
+      }}
+      transformOrigin={{
+        vertical: 'center',
+        horizontal: 'left',
+      }}
+      style={{
+        marginLeft: '70px'
+      }}
     >
-      <DialogTitle>
+      <Box className={classes.titleBox} display="flex" alignItems="center" justifyContent="space-between">
         Neuron Size
         <IconButton onClick={onClose}>
           <img src={CLOSE} alt="close" />
         </IconButton>
-      </DialogTitle>
-      <DialogContent>
+      </Box>
+      <Box>
 
-        <Box className={classes.dialogContent}>
+        <Box className={classes.popoverContent}>
           <Box >
             {
               dialogPopulationsSelected?.showAll && (
@@ -241,9 +241,9 @@ const NeuronDotSize = ({
             }
           </Box>
         </Box>
-      </DialogContent>
+      </Box>
 
-    </Dialog>
+    </Popover>
   );
 };
 

--- a/applications/portal/frontend/src/components/sidebar/CustomAccordionSummary.jsx
+++ b/applications/portal/frontend/src/components/sidebar/CustomAccordionSummary.jsx
@@ -36,10 +36,9 @@ const CustomAccordionSummary = ({
     handlePopulationSwitch,
     handlePopulationColorChange,
     hasEditPermission,
-    dotSizeDialogOpen,
-    setDotSizeDialogOpen,
     setDialogPopulationsSelected,
-    setPopulationRefPosition
+    handleDotSizeClick,
+    dotSizeId
 }) => {
     const [popoverAnchorEl, setPopoverAnchorEl] = React.useState(null);
     const [selectedPopoverId, setSelectedPopoverId] = React.useState(null);
@@ -80,8 +79,9 @@ const CustomAccordionSummary = ({
     const status = isParent ? getParentPopulationStatus(population) : population.status
     const checked = isParent ? areAllSelected(population.children) : population.selected
 
-    const selectPopulationForDotSizeChange = (population) => {
-        setDotSizeDialogOpen(!dotSizeDialogOpen)
+    const selectPopulationForDotSizeChange = (e, population) => {
+
+        handleDotSizeClick(e)
 
         const children = population?.children
         if (children) {
@@ -175,8 +175,8 @@ const CustomAccordionSummary = ({
                             {
                                 checked && (
                                     <DotSizeButton
-                                        onClickFunc={() => selectPopulationForDotSizeChange(population)}
-                                        setPopulationRefPosition={setPopulationRefPosition}
+                                        dotSizeId={dotSizeId}
+                                        onClickFunc={(e) => selectPopulationForDotSizeChange(e, population)}
                                     />
                                 )
                             }

--- a/applications/portal/frontend/src/components/sidebar/DotSizeButton.jsx
+++ b/applications/portal/frontend/src/components/sidebar/DotSizeButton.jsx
@@ -3,18 +3,14 @@ import { IconButton } from "@material-ui/core";
 import { SliderIcon } from "../icons";
 
 
-export const DotSizeButton = ({ onClickFunc, setPopulationRefPosition }) => {
-  const myRef = React.useRef(null);
+export const DotSizeButton = ({ dotSizeId, onClickFunc}) => {
   return (
     <IconButton
       edge="end"
       color="inherit"
-      onClick={() => {
-        onClickFunc()
-        setPopulationRefPosition(myRef.current.getBoundingClientRect())
-      }}
+      aria-describedby={dotSizeId}
+      onClick={onClickFunc}
       className='slider-icon'
-      ref={myRef}
     >
       <SliderIcon style={{ height: '0.90rem' }} />
     </IconButton>

--- a/applications/portal/frontend/src/components/sidebar/ExperimentSidebar.jsx
+++ b/applications/portal/frontend/src/components/sidebar/ExperimentSidebar.jsx
@@ -310,7 +310,8 @@ const ExperimentSidebar = ({
     dotSizeDialogOpen,
     setDotSizeDialogOpen,
     setDialogPopulationsSelected,
-    setPopulationRefPosition
+    handleDotSizeClick,
+    dotSizeId
 }) => {
     const classes = useStyles();
     const [shrink, setShrink] = useState(false);
@@ -387,7 +388,8 @@ const ExperimentSidebar = ({
                         dotSizeDialogOpen={dotSizeDialogOpen}
                         setDotSizeDialogOpen={setDotSizeDialogOpen}
                         setDialogPopulationsSelected={setDialogPopulationsSelected}
-                        setPopulationRefPosition={setPopulationRefPosition}
+                        handleDotSizeClick={handleDotSizeClick}
+                        dotSizeId={dotSizeId}
                     />
 
                     <PopulationsAccordion populations={experimentPopulationsWithChildren} icon={POPULATION}
@@ -402,7 +404,8 @@ const ExperimentSidebar = ({
                         dotSizeDialogOpen={dotSizeDialogOpen}
                         setDotSizeDialogOpen={setDotSizeDialogOpen}
                         setDialogPopulationsSelected={setDialogPopulationsSelected}
-                        setPopulationRefPosition={setPopulationRefPosition}
+                        handleDotSizeClick={handleDotSizeClick}
+                        dotSizeId={dotSizeId}
                     />
 
                 </>

--- a/applications/portal/frontend/src/components/sidebar/PopulationsAccordion.jsx
+++ b/applications/portal/frontend/src/components/sidebar/PopulationsAccordion.jsx
@@ -33,10 +33,9 @@ const PopulationsAccordion = ({
     handlePopulationColorChange,
     handleChildPopulationSwitch,
     handleParentPopulationSwitch,
-    dotSizeDialogOpen,
-    setDotSizeDialogOpen,
     setDialogPopulationsSelected,
-    setPopulationRefPosition
+    handleDotSizeClick,
+    dotSizeId
 }) => {
     const [expanded, setExpanded] = React.useState({});
     const api = workspaceService.getApi()
@@ -72,8 +71,10 @@ const PopulationsAccordion = ({
         ? 'Download active populations data'
         : 'No active populations to download';
 
-    const selectAllPopulationsForDotSizeChange = () => {
-        setDotSizeDialogOpen(!dotSizeDialogOpen)
+    const selectAllPopulationsForDotSizeChange = (e) => {
+
+        handleDotSizeClick(e)
+
         let populationsToSelect = {}
         for (const populationId in populations) {
             const population = populations[populationId]
@@ -114,11 +115,8 @@ const PopulationsAccordion = ({
                         {
                             areAllPopulationsWithChildrenSelected(populations) && (
                                 <DotSizeButton
-                                    onClickFunc={() => {
-                                        setDotSizeDialogOpen(!dotSizeDialogOpen)
-                                        selectAllPopulationsForDotSizeChange()
-                                    }}
-                                    setPopulationRefPosition={setPopulationRefPosition}
+                                    dotSizeId={dotSizeId}
+                                    onClickFunc={(e) => selectAllPopulationsForDotSizeChange(e)}
                                 />
                             )
                         }
@@ -148,10 +146,9 @@ const PopulationsAccordion = ({
                                     handlePopulationsWithChildrenColorChange(populations[pId], color, opacity)
                                 }
                                 hasEditPermission={hasEditPermission}
-                                dotSizeDialogOpen={dotSizeDialogOpen}
-                                setDotSizeDialogOpen={setDotSizeDialogOpen}
                                 setDialogPopulationsSelected={setDialogPopulationsSelected}
-                                setPopulationRefPosition={setPopulationRefPosition}
+                                handleDotSizeClick={handleDotSizeClick}
+                                dotSizeId={dotSizeId}
                             />
                             {
                                 populations[pId]?.children && <AccordionDetails>
@@ -176,6 +173,8 @@ const PopulationsAccordion = ({
                                                             }])}
 
                                                         hasEditPermission={hasEditPermission}
+                                                        handleDotSizeClick={handleDotSizeClick}
+                                                        dotSizeId={dotSizeId}
                                                     />
                                                 </Accordion>
                                             </span>

--- a/applications/portal/frontend/src/pages/ExperimentsPage.tsx
+++ b/applications/portal/frontend/src/pages/ExperimentsPage.tsx
@@ -86,7 +86,6 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({ residentia
     const [selectedAtlas, setSelectedAtlas] = useState(getDefaultAtlas());
     const [populations, setPopulations] = useState<PopulationDataType>({});
     const subdivisions = getSubdivisions(selectedAtlas);
-    const [dotSizeDialogOpen, setDotSizeDialogOpen] = useState(false);
     const [dialogPopulationsSelected, setDialogPopulationsSelected] = useState(null);
     const [populationDotSizes, setPopulationDotSizes] = useState<DotSizeType>({})
     const [errorMessage, setErrorMessage] = React.useState('');
@@ -390,7 +389,18 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({ residentia
         }
     }, [store])
 
-    const [populationRefPosition, setPopulationRefPosition] = useState(null)
+    const [anchorElDotSize, setAnchorElDotSize] = React.useState(null);
+
+    const handleDotSizeClick = (event: any) => {
+        setAnchorElDotSize(anchorElDotSize ? null : event.currentTarget);
+    };
+
+    const handleCloseDotSizePopover = () => {
+        setAnchorElDotSize(null);
+    };
+
+    const dotSizeOpen = Boolean(anchorElDotSize);
+    const dotSizeId = open ? 'simple-popper' : undefined;
 
     return experiment != null ? (
         <Box display="flex">
@@ -404,17 +414,17 @@ const ExperimentsPage: React.FC<{ residentialPopulations: any }> = ({ residentia
                 handleShowAllPopulations={handleShowAllPopulations}
                 handlePopulationColorChange={handlePopulationColorChange}
                 hasEditPermission={experiment.has_edit_permission}
-                dotSizeDialogOpen={dotSizeDialogOpen}
-                setDotSizeDialogOpen={setDotSizeDialogOpen}
+                handleDotSizeClick={handleDotSizeClick}
                 setDialogPopulationsSelected={setDialogPopulationsSelected}
-                setPopulationRefPosition={setPopulationRefPosition}
+                dotSizeId={dotSizeId}
             />
             <Box className={classes.layoutContainer}>
                 <NeuronDotSize
-                    open={dotSizeDialogOpen}
-                    onClose={() => setDotSizeDialogOpen(false)}
+                    open={dotSizeOpen}
+                    id={dotSizeId}
+                    onClose={handleCloseDotSizePopover}
                     populations={populations}
-                    anchorElement={populationRefPosition}
+                    anchorElement={anchorElDotSize}
                     activePopulations={getActivePopulations()}
                     handleSubPopulationDotSizeChange={handleSubPopulationDotSizeChange}
                     dialogPopulationsSelected={dialogPopulationsSelected}


### PR DESCRIPTION
Issue #337 
Problem: Cell size slider misplaced
Solution: 
Dialog component made it difficult to view as it is not supposed to act as a popper component, also causing unnecessary background color
<img width="522" alt="image" src="https://github.com/MetaCell/salk-interactive-atlas/assets/67194168/67306fb6-4d95-42d9-b373-c115d1d035b4">
