### PR TITLE
340 Disable 'show all' when there are no populations

### DIFF
--- a/applications/portal/frontend/src/components/sidebar/PopulationsAccordion.jsx
+++ b/applications/portal/frontend/src/components/sidebar/PopulationsAccordion.jsx
@@ -16,7 +16,7 @@ import UP_ICON from "../../assets/images/icons/up.svg";
 import CustomAccordionSummary from "./CustomAccordionSummary";
 import DOWNLOAD_ICON from "../../assets/images/icons/download_icon.svg";
 import { downloadFile } from "../../utils";
-import { areAllPopulationsWithChildrenSelected, areAllPopulationsWithChildrenCells } from "../../utilities/functions";
+import { areAllPopulationsWithChildrenSelected, areAllPopulationsWithStatusFinished } from "../../utilities/functions";
 import workspaceService from "../../service/WorkspaceService";
 import { useParams } from "react-router";
 import { DotSizeButton } from './DotSizeButton';
@@ -94,7 +94,6 @@ const PopulationsAccordion = ({
         })
     }
 
-    console.log('populations: ', populations)
 
     return (
         <Accordion elevation={0} square defaultExpanded={true}>
@@ -129,8 +128,8 @@ const PopulationsAccordion = ({
                                 <Switch />
                             }
                             onChange={handleShowAllPopulations}
-                            disabled={areAllPopulationsWithChildrenCells(populations)}
                             checked={areAllPopulationsWithChildrenSelected(populations)}
+                            disabled={areAllPopulationsWithStatusFinished(populations)}
                         />
                     </Box>
                 </Box>

--- a/applications/portal/frontend/src/components/sidebar/PopulationsAccordion.jsx
+++ b/applications/portal/frontend/src/components/sidebar/PopulationsAccordion.jsx
@@ -16,7 +16,7 @@ import UP_ICON from "../../assets/images/icons/up.svg";
 import CustomAccordionSummary from "./CustomAccordionSummary";
 import DOWNLOAD_ICON from "../../assets/images/icons/download_icon.svg";
 import { downloadFile } from "../../utils";
-import { areAllPopulationsWithChildrenSelected } from "../../utilities/functions";
+import { areAllPopulationsWithChildrenSelected, areAllPopulationsWithChildrenCells } from "../../utilities/functions";
 import workspaceService from "../../service/WorkspaceService";
 import { useParams } from "react-router";
 import { DotSizeButton } from './DotSizeButton';
@@ -94,6 +94,7 @@ const PopulationsAccordion = ({
         })
     }
 
+    console.log('populations: ', populations)
 
     return (
         <Accordion elevation={0} square defaultExpanded={true}>
@@ -128,6 +129,7 @@ const PopulationsAccordion = ({
                                 <Switch />
                             }
                             onChange={handleShowAllPopulations}
+                            disabled={areAllPopulationsWithChildrenCells(populations)}
                             checked={areAllPopulationsWithChildrenSelected(populations)}
                         />
                     </Box>

--- a/applications/portal/frontend/src/utilities/functions.ts
+++ b/applications/portal/frontend/src/utilities/functions.ts
@@ -30,18 +30,18 @@ export const areAllPopulationsWithChildrenSelected = (obj: {
     return Object.keys(obj).every(pId => {
         const children = obj[pId].children;
         if (children) {
-            return Object.keys(children).every(childId => children[childId].selected);
+            return Object.keys(children).some(childId => children[childId].selected);
         }
 
         return true;
     });
 }
 
-export const areAllPopulationsWithChildrenCells = (obj: {
+export const areAllPopulationsWithStatusFinished = (obj: {
     [x: string]: {
         children?: {
             [childId: string]: {
-                cells: any
+                status: string
             }
         }
     }
@@ -49,7 +49,7 @@ export const areAllPopulationsWithChildrenCells = (obj: {
     return Object.keys(obj).every(pId => {
         const children = obj[pId].children;
         if (children) {
-            return Object.keys(children).every(childId => children[childId].cells === null || (Array.isArray(children[childId].cells) && children[childId].cells.length === 0));
+            return Object.keys(children).every(childId => children[childId].status !== POPULATION_FINISHED_STATE);
         }
 
         return true;

--- a/applications/portal/frontend/src/utilities/functions.ts
+++ b/applications/portal/frontend/src/utilities/functions.ts
@@ -37,6 +37,26 @@ export const areAllPopulationsWithChildrenSelected = (obj: {
     });
 }
 
+export const areAllPopulationsWithChildrenCells = (obj: {
+    [x: string]: {
+        children?: {
+            [childId: string]: {
+                cells: any
+            }
+        }
+    }
+}): boolean => {
+    return Object.keys(obj).every(pId => {
+        const children = obj[pId].children;
+        if (children) {
+            return Object.keys(children).every(childId => children[childId].cells === null || (Array.isArray(children[childId].cells) && children[childId].cells.length === 0));
+        }
+
+        return true;
+    });
+}
+
+
 export const areSomeSelected = (obj: {
     [x: string]: {
         selected: any


### PR DESCRIPTION
Issue #340 
Problem: Disable 'show all' when there are no populations
Solution: Added function which checks if population children have cells or not, in case if they don't function returns true and making switch disabled

<img width="182" alt="image" src="https://github.com/MetaCell/salk-interactive-atlas/assets/67194168/da335764-ed57-4d22-88e8-fdf2c73395e1">
<img width="183" alt="image" src="https://github.com/MetaCell/salk-interactive-atlas/assets/67194168/8e0bfc58-ac34-49b9-94e1-b1fa8bea6da0">
